### PR TITLE
Handle SIGKILL without an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -360,6 +360,13 @@ module.exports = function Constructor(customSettings) {
 		
 		// Wait for exit
 		child.on('exit', (code) => {
+			// Handle a SIGKILL
+			if (code === null) {
+				console.log(); // Ensure it goes to the next line
+				process.exit();
+			}
+			
+			
 			// Handle an issue
 			if (code !== 0) {
 				throw new ErrorWithoutStack(`Received exit code ${code} from: ${paths[0]}\nSee above output`);


### PR DESCRIPTION
Resolves #48 

Instead of throwing an error whenever a spawned command is killed, just exit.