### PR TITLE
Provide spawned commands a way to tap into our error displaying

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,9 @@ const utils = require('./utils.js');
 // Handle exceptions
 process.on('uncaughtException', (error) => {
 	console.error(`${' ERROR '.inverse.red.bold}\n`);
-	console.error((`> ${error.stack.split('\n').join('\n> ')}\n`).red);
+	console.error((`> ${error.stack.replace(/^COMMAND ERROR: /, '').split('\n').join('\n> ')}\n`).red);
 	
-	process.exit(255);
+	process.exit(error.stack.match(/COMMAND ERROR: /) ? 255 : 1);
 });
 
 
@@ -408,5 +408,5 @@ module.exports.command = function command() {
 
 // A helper function provided to commands to keep error messages consistent
 module.exports.error = function error(message) {
-	throw new ErrorWithoutStack(message);
+	throw new ErrorWithoutStack('COMMAND ERROR: '+message);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ process.on('uncaughtException', (error) => {
 	console.error(`${' ERROR '.inverse.red.bold}\n`);
 	console.error((`> ${error.stack.split('\n').join('\n> ')}\n`).red);
 	
-	process.exit(1);
+	process.exit(255);
 });
 
 
@@ -367,6 +367,12 @@ module.exports = function Constructor(customSettings) {
 			}
 			
 			
+			// Handle if error message already happened
+			if (code === 255) {
+				process.exit(1);
+			}
+			
+			
 			// Handle an issue
 			if (code !== 0) {
 				throw new ErrorWithoutStack(`Received exit code ${code} from: ${paths[0]}\nSee above output`);
@@ -398,4 +404,10 @@ module.exports = function Constructor(customSettings) {
 // The function used to kick off commands
 module.exports.command = function command() {
 	return JSON.parse(process.argv[2]);
+};
+
+
+// A helper function provided to commands to keep error messages consistent
+module.exports.error = function error(message) {
+	throw new ErrorWithoutStack(message);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -408,5 +408,5 @@ module.exports.command = function command() {
 
 // A helper function provided to commands to keep error messages consistent
 module.exports.error = function error(message) {
-	throw new ErrorWithoutStack('COMMAND ERROR: '+message);
+	throw new ErrorWithoutStack(`COMMAND ERROR: ${message}`);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ const utils = require('./utils.js');
 
 // Handle exceptions
 process.on('uncaughtException', (error) => {
-	console.error();
 	console.error(`${' ERROR '.inverse.red.bold}\n`);
 	console.error((`> ${error.stack.split('\n').join('\n> ')}\n`).red);
 	
@@ -26,6 +25,12 @@ module.exports = function Constructor(customSettings) {
 	Object.assign(settings, customSettings);
 	
 	
+	// Add spacing before
+	for (let i = 0; i < settings.spacing.before; i += 1) {
+		console.log();
+	}
+	
+	
 	// Determine app information
 	settings.app = utils(settings).retrieveAppInformation();
 	
@@ -37,12 +42,6 @@ module.exports = function Constructor(customSettings) {
 	
 	// Organize the arguments
 	const organizedArguments = utils(settings).organizeArguments();
-	
-	
-	// Add spacing before
-	for (let i = 0; i < settings.spacing.before; i += 1) {
-		console.log();
-	}
 	
 	
 	// Handle --version


### PR DESCRIPTION
Resolves #50 

This allows commands to execute `require('waterfall-cli').error('Custom message');` to display an error and kill the program, using the same exact formatting and style that Waterfall CLI uses.