### PR TITLE
Clearer errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -702,6 +702,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "fuse.js": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.3.tgz",
+      "integrity": "sha512-XhUzonuhVsxzoBMPQsax7Vzz1n9tnj0S0Ev/c1qzx4SUyd/LFWuSonhdEKtXsAaZzq96QYleWBPDvRiZ7onw8Q=="
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/sparksuite/waterfall-cli",
   "dependencies": {
     "cli-table": "^0.3.1",
-    "colors": "^1.3.3"
+    "colors": "^1.3.3",
+    "fuse.js": "^3.4.3"
   },
   "devDependencies": {
     "eslint": "^5.15.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -333,8 +333,9 @@ module.exports = function Constructor(currentSettings) {
 					// Check if data is allowed
 					if (!mergedSpec.data || !mergedSpec.data.description) {
 						// Get all commands in program
-						let commands = module.exports(settings).files.getAllDirectories(path.dirname(settings.mainFilename));
-						commands = commands.map(file => file.replace(`${path.dirname(settings.mainFilename)}/`, ''));
+						const mainDir = path.dirname(settings.mainFilename);
+						let commands = module.exports(settings).files.getAllDirectories(mainDir);
+						commands = commands.map(file => file.replace(`${mainDir}/`, ''));
 						commands = commands.map(file => file.replace(/\.js$/, ''));
 						commands = commands.map(file => file.replace(/\//, ' '));
 						
@@ -349,7 +350,7 @@ module.exports = function Constructor(currentSettings) {
 							minMatchCharLength: 1,
 						});
 						
-						let results = fuse.search(`${organizedArguments.command} ${fullData}`.trim());
+						const results = fuse.search(`${organizedArguments.command} ${fullData}`.trim());
 						let bestMatch = null;
 						
 						if (results.length) {
@@ -358,7 +359,7 @@ module.exports = function Constructor(currentSettings) {
 						
 						
 						// Determine command
-						let command = `${settings.usageCommand}${organizedArguments.command}`;
+						const command = `${settings.usageCommand}${organizedArguments.command}`;
 						
 						
 						// Form error message


### PR DESCRIPTION
Resolves #45 

Errors for non-existent commands (which are handled like non-permitted data), are much clearer. The explanation does a better job of explaining what's going on and how to get help. Plus, it even makes a suggestion for a command, if possible (in case there was simply a typo).

Suggestions are handled by running all of the program's commands through a Fuse.js search, to find the closest match. But it only suggests it if the match is sufficiently close.

### If a suggestion is found:
![](https://cl.ly/21f65afa2873/Image%202019-03-08%20at%202.49.42%20PM.png)

### If a suggestion is not found:
![](https://cl.ly/6e66d38d14af/Image%202019-03-08%20at%202.51.43%20PM.png)