### PR TITLE
Don't match require all tokens to match for suggestions

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -341,7 +341,6 @@ module.exports = function Constructor(currentSettings) {
 							shouldSort: true,
 							threshold: 0.4,
 							tokenize: true,
-							matchAllTokens: true,
 							maxPatternLength: 32,
 							minMatchCharLength: 1,
 						});


### PR DESCRIPTION
Resolves #66 

Now, things like `node entry.js listt toppings` will make an intelligent suggestion.