### PR TITLE
Improve intelligent suggestions

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -339,8 +339,10 @@ module.exports = function Constructor(currentSettings) {
 						// Search for the best match
 						const fuse = new Fuse(commands, {
 							shouldSort: true,
-							threshold: 0.4,
+							threshold: 1,
 							tokenize: true,
+							includeScore: true,
+							includeMatches: true,
 							maxPatternLength: 32,
 							minMatchCharLength: 1,
 						});
@@ -348,8 +350,8 @@ module.exports = function Constructor(currentSettings) {
 						const results = fuse.search(`${organizedArguments.command} ${fullData}`.trim());
 						let bestMatch = null;
 						
-						if (results.length) {
-							bestMatch = commands[results[0]];
+						if (results.length && results[0].score < 0.6) {
+							bestMatch = results[0].matches[0].value;
 						}
 						
 						


### PR DESCRIPTION
In testing, if you reversed the words for a command two levels deep (e.g. `node entry.js dine-in order` instead of `node entry.js order dine-in`), it wouldn't intelligently suggest `node entry.js order dine-in`. Instead, it would suggest the less-likely `node entry.js order`.

After toying with the settings on https://fusejs.io/ using real data, I've updated the search settings to be more likely to produce the intended command.