### PR TITLE
Fix issue preventing help screen from appearing for commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "waterfall-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterfall-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Effortlessly create CLIs powered by Node.js",
   "main": "src/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -44,12 +44,8 @@ module.exports = function Constructor(customSettings) {
 	const organizedArguments = utils(settings).organizeArguments();
 	
 	
-	// Construct the input object
-	const inputObject = utils(settings).constructInputObject(organizedArguments);
-	
-	
 	// Handle --version
-	if (inputObject.version) {
+	if (organizedArguments.flags.includes('version')) {
 		// Output
 		process.stdout.write(screens(settings).version());
 		
@@ -64,7 +60,7 @@ module.exports = function Constructor(customSettings) {
 	
 	
 	// Handle --help
-	if (inputObject.help) {
+	if (organizedArguments.flags.includes('help')) {
 		// Output
 		process.stdout.write(screens(settings).help());
 		
@@ -112,6 +108,10 @@ module.exports = function Constructor(customSettings) {
 			executionPaths.push(commandPath);
 		}
 	});
+	
+	
+	// Construct the input object
+	const inputObject = utils(settings).constructInputObject(organizedArguments);
 	
 	
 	// Verbose output

--- a/test/pizza-ordering.js
+++ b/test/pizza-ordering.js
@@ -78,13 +78,19 @@ describe('Pizza ordering', () => {
 			], undefined, done);
 		});
 		
+		it('Displays version for a command', (done) => {
+			runTest('list --version', [
+				'pizza-ordering: 1.2.3',
+			], undefined, done);
+		});
+		
 		it('Displays help screen', (done) => {
 			runTest('--help', [
 				'Usage: node entry.js [commands]',
 			], undefined, done);
 		});
 		
-		it('Displays help screen for sub-command', (done) => {
+		it('Displays help screen for a command', (done) => {
 			runTest('list --help', [
 				'Usage: node entry.js list [flags]',
 			], undefined, done);

--- a/test/pizza-ordering.js
+++ b/test/pizza-ordering.js
@@ -77,5 +77,17 @@ describe('Pizza ordering', () => {
 				'pizza-ordering: 1.2.3',
 			], undefined, done);
 		});
+		
+		it('Displays help screen', (done) => {
+			runTest('--help', [
+				'Usage: node entry.js [commands]',
+			], undefined, done);
+		});
+		
+		it('Displays help screen for sub-command', (done) => {
+			runTest('list --help', [
+				'Usage: node entry.js list [flags]',
+			], undefined, done);
+		});
 	});
 });


### PR DESCRIPTION
Help screens were not appearing for commands, because of when the input object was being constructed. I also added test cases for this to help prevent this issue from slipping by in the future.