### PR TITLE
Fix how Node.js arguments are passed

### DIFF
--- a/test/run-program.js
+++ b/test/run-program.js
@@ -19,7 +19,7 @@ module.exports = function runProgram(
 	return new Promise(resolve => {
 		// Build the array of all arguments
 		let allArguments = [
-			...nodeArguments,
+			...nodeArguments.split(' '),
 			entryFile,
 			...programArguments.split(' '),
 		];


### PR DESCRIPTION
They should be passed in as a string with spaces separating each.