### PR TITLE
Fix tests on LTS node for the ES6 import program

### DIFF
--- a/test/es6-imports.test.js
+++ b/test/es6-imports.test.js
@@ -12,17 +12,15 @@ if (semver.lt(semver.clean(process.version), '12.0.0')) {
 	test('Tests disabled on Node.js versions older than v12', () => {
 		expect(true).toBe(true);
 	});
-
-	process.exit();
-}
-
-// Tests
-describe('Built-in abilities', () => {
-	test('Displays version', () => {
-		return runProgram(entryFile, '--version', '--experimental-modules').then(
-			({ stdout }) => {
-				expect(stdout.includes('es6-imports: 1.2.3')).toBe(true);
-			}
-		);
+} else {
+	// Tests
+	describe('Built-in abilities', () => {
+		test('Displays version', () => {
+			return runProgram(entryFile, '--version', '--experimental-modules').then(
+				({ stdout }) => {
+					expect(stdout.includes('es6-imports: 1.2.3')).toBe(true);
+				}
+			);
+		});
 	});
-});
+}


### PR DESCRIPTION
The `process.exit()` function threw an error and sometimes caused the tests to run indefinitely.