### PR TITLE
Fix CI not running for Codecov or Greenkeeper as expected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,13 @@ branches:
 jobs:
   include:
     - stage: test
-      if: type = pull_request OR tag IS present
       name: Lint code
       node_js: lts/*
       script: npm run lint
     - stage: test
-      if: type = pull_request OR tag IS present
       name: Run tests (Node.js Current)
       node_js: node
     - stage: test
-      if: type = pull_request OR tag IS present
       name: Run tests (Node.js LTS)
       node_js: lts/*
       script:


### PR DESCRIPTION
The test stage's jobs are only running for pull requests and tags. However, we need these to also run on the branches specified in the `branches.only` key. This way, Codecov is always given the latest coverage report from `master` and Greenkeeper's branches have commit statuses reported to them.