### PR TITLE
Fix inconsistent treatment of data's description

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
 	],
 	"scripts": {
 		"test": "npm run compile && tsc --project test/programs/typescript && jest",
-		"lint": "eslint --ext .js,.ts src test && prettier --check '**/*.{ts,js,json}'",
-		"format": "eslint --fix --ext .js,.ts src test && prettier --write '**/*.{ts,js,json}'",
+		"lint": "eslint --ext .js,.ts . && prettier --check '**/*.{ts,js,json}'",
+		"format": "eslint --fix --ext .js,.ts . && prettier --write '**/*.{ts,js,json}'",
 		"compile": "tsc"
 	},
 	"repository": {

--- a/src/screens.js
+++ b/src/screens.js
@@ -94,11 +94,11 @@ module.exports = function Constructor(currentSettings) {
 				hasOptions = true;
 			}
 
-			// Determine if it accepts data
-			let acceptsData = false;
+			// Determine if it allows data
+			let allowsData = false;
 
 			if (typeof mergedSpec.data === 'object') {
-				acceptsData = true;
+				allowsData = true;
 			}
 
 			// Determine if there are commands
@@ -122,7 +122,7 @@ module.exports = function Constructor(currentSettings) {
 			usageLine += chalk.gray(hasCommands ? ' [commands]' : '');
 			usageLine += chalk.gray(hasFlags ? ' [flags]' : '');
 			usageLine += chalk.gray(hasOptions ? ' [options]' : '');
-			usageLine += chalk.gray(acceptsData ? ' [data]' : '');
+			usageLine += chalk.gray(allowsData ? ' [data]' : '');
 
 			outputString += `${usageLine}\n`;
 
@@ -224,7 +224,7 @@ module.exports = function Constructor(currentSettings) {
 			outputString += `${table.toString()}\n`;
 
 			// Handle data
-			if (acceptsData) {
+			if (allowsData) {
 				// Print header
 				outputString += '\nDATA:\n';
 

--- a/src/screens.js
+++ b/src/screens.js
@@ -233,6 +233,8 @@ module.exports = function Constructor(currentSettings) {
 
 				if (mergedSpec.data.description) {
 					fullDescription += mergedSpec.data.description;
+				} else {
+					fullDescription += 'This command allows data to be passed in';
 				}
 
 				if (mergedSpec.data.required) {

--- a/src/screens.js
+++ b/src/screens.js
@@ -97,7 +97,7 @@ module.exports = function Constructor(currentSettings) {
 			// Determine if it accepts data
 			let acceptsData = false;
 
-			if (mergedSpec.data && mergedSpec.data.description) {
+			if (typeof mergedSpec.data === 'object') {
 				acceptsData = true;
 			}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -358,8 +358,8 @@ module.exports = function Constructor(currentSettings) {
 					.exports(settings)
 					.getMergedSpec(organizedArguments.command);
 
-				// Check if data is allowed
-				if (!mergedSpec.data || !mergedSpec.data.description) {
+				// Handle if data is not allowed
+				if (typeof mergedSpec.data !== 'object') {
 					// Get all commands in this program
 					const commands = module.exports(settings).getAllProgramCommands();
 

--- a/test/programs/pizza-ordering/cli/order/descriptionless-data/descriptionless-data.json
+++ b/test/programs/pizza-ordering/cli/order/descriptionless-data/descriptionless-data.json
@@ -1,0 +1,4 @@
+{
+	"description": "Just used for testing",
+	"data": {}
+}

--- a/test/screens.test.js
+++ b/test/screens.test.js
@@ -344,6 +344,27 @@ describe('#help()', () => {
 		).toBe(true);
 	});
 
+	test('Data - no description', () => {
+		const settings = {
+			...defaultSettings,
+			mainFilename: `${__dirname}/programs/pizza-ordering/cli/entry.js`,
+			usageCommand: 'node entry.js',
+			arguments: ['order', 'descriptionless-data'],
+		};
+
+		expect(
+			removeFormatting(screens(settings).help()).includes(
+				'DATA:'
+			)
+		).toBe(true);
+
+		expect(
+			removeFormatting(screens(settings).help()).includes(
+				'This command allows data to be passed in'
+			)
+		).toBe(true);
+	});
+
 	test('Data - description (required + accepts)', () => {
 		const settings = {
 			...defaultSettings,

--- a/test/screens.test.js
+++ b/test/screens.test.js
@@ -352,11 +352,9 @@ describe('#help()', () => {
 			arguments: ['order', 'descriptionless-data'],
 		};
 
-		expect(
-			removeFormatting(screens(settings).help()).includes(
-				'DATA:'
-			)
-		).toBe(true);
+		expect(removeFormatting(screens(settings).help()).includes('DATA:')).toBe(
+			true
+		);
 
 		expect(
 			removeFormatting(screens(settings).help()).includes(

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -813,6 +813,7 @@ describe('#getAllProgramCommands()', () => {
 		expect(utils(settingsPizzaOrdering).getAllProgramCommands()).toStrictEqual([
 			'list',
 			'order',
+			'order descriptionless-data',
 			'order dine-in',
 			'order float-data',
 			'order integer-data',


### PR DESCRIPTION
This issue stems from https://github.com/sparksuite/waterfall-cli/pull/100#discussion_r332719121.

Basically, the `description` for `data` is sometimes treated as required, sometimes as optional. We've decided to make it always optional, in line with how descriptions are treated elsewhere for options, flags, and commands.

This means a generic description is now provided to the end-user if no custom one is provided. To indicate a command allows data, the client would need to provide at least `"data": {}` inside the command's specs. The key being the fact that `data` is present and it's an object.