### PR TITLE
Set up project exports for consistent client usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-// Imports
-import { init, command, error } from './waterfall-cli';
-
 // Exports
-export { init, command, error };
+export { init, command, error } from './waterfall-cli';
 export { Settings } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+// Imports
+import { init, command, error } from './waterfall-cli';
+
+// Exports
+export { init, command, error };
+export { Settings } from './types';

--- a/src/waterfall-cli.js
+++ b/src/waterfall-cli.js
@@ -18,7 +18,7 @@ process.on('uncaughtException', error => {
 });
 
 // The constructor, for use at the entry point
-module.exports = function Constructor(customSettings) {
+module.exports.init = function init(customSettings) {
 	// Merge custom settings into default settings
 	const settings = deepmerge(defaultSettings, customSettings);
 

--- a/test/programs/bad-structure/cli/entry.js
+++ b/test/programs/bad-structure/cli/entry.js
@@ -1,4 +1,6 @@
-// Initialize Waterfall CLI
-require('../../../../dist').init({
+// Import and initialize Waterfall CLI
+const waterfall = require('../../../../dist')
+
+waterfall.init({
 	verbose: true,
 });

--- a/test/programs/bad-structure/cli/entry.js
+++ b/test/programs/bad-structure/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-const waterfall = require('../../../../dist')
+const waterfall = require('../../../../dist/index.js');
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/bad-structure/cli/entry.js
+++ b/test/programs/bad-structure/cli/entry.js
@@ -1,4 +1,4 @@
 // Initialize Waterfall CLI
-require('../../../../dist/index.js')({
+require('../../../../dist').init({
 	verbose: true,
 });

--- a/test/programs/es6-imports/cli/entry.js
+++ b/test/programs/es6-imports/cli/entry.js
@@ -1,6 +1,6 @@
 // Import and initialize Waterfall CLI
-import waterfallCLI from '../../../../dist/index.js';
+import waterfall from '../../../../dist/index.js';
 
-waterfallCLI({
+waterfall.init({
 	verbose: true,
 });

--- a/test/programs/es6-imports/cli/entry.js
+++ b/test/programs/es6-imports/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall from '../../../../dist/index.js';
+import waterfall from '../../../../dist';
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/es6-imports/cli/entry.js
+++ b/test/programs/es6-imports/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall from '../../../../dist';
+import waterfall from '../../../../dist/index.js';
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/pizza-ordering/cli/entry.js
+++ b/test/programs/pizza-ordering/cli/entry.js
@@ -1,4 +1,6 @@
-// Initialize Waterfall CLI
-require('../../../../dist').init({
+// Import and initialize Waterfall CLI
+const waterfall = require('../../../../dist')
+
+waterfall.init({
 	verbose: true,
 });

--- a/test/programs/pizza-ordering/cli/entry.js
+++ b/test/programs/pizza-ordering/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-const waterfall = require('../../../../dist')
+const waterfall = require('../../../../dist/index.js');
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/pizza-ordering/cli/entry.js
+++ b/test/programs/pizza-ordering/cli/entry.js
@@ -1,4 +1,4 @@
 // Initialize Waterfall CLI
-require('../../../../dist/index.js')({
+require('../../../../dist').init({
 	verbose: true,
 });

--- a/test/programs/pizza-ordering/cli/list/list.js
+++ b/test/programs/pizza-ordering/cli/list/list.js
@@ -1,4 +1,8 @@
-// Parse command input
-const input = require('../../../../../dist/index.js').command();
+// Require Waterfall CLI
+const waterfall = require('../../../../../dist');
 
+// Parse command input
+const input = waterfall.command();
+
+// Output result
 console.log(input);

--- a/test/programs/pizza-ordering/cli/list/list.js
+++ b/test/programs/pizza-ordering/cli/list/list.js
@@ -1,5 +1,5 @@
 // Require Waterfall CLI
-const waterfall = require('../../../../../dist');
+const waterfall = require('../../../../../dist/index.js');
 
 // Parse command input
 const input = waterfall.command();

--- a/test/programs/typescript/src/entry.ts
+++ b/test/programs/typescript/src/entry.ts
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall = require('../../../../dist');
+import waterfall = require('../../../../dist/index.js');
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/typescript/src/entry.ts
+++ b/test/programs/typescript/src/entry.ts
@@ -1,6 +1,6 @@
 // Import and initialize Waterfall CLI
-import waterfallCLI from '../../../../dist/index.js';
+import waterfall = require('../../../../dist');
 
-waterfallCLI({
+waterfall.init({
 	verbose: true,
 });


### PR DESCRIPTION
Move `index.js` to `waterfall-cli.js`, introduce new `index.ts` with exports, change exported names to provide a consistent client usage of the functionality.