### PR TITLE
Remove need to require files with `.js` extension

### DIFF
--- a/src/screens.js
+++ b/src/screens.js
@@ -1,7 +1,7 @@
 // Dependencies
 const chalk = require('chalk');
 const Table = require('cli-table');
-const utils = require('./utils.js');
+const utils = require('./utils');
 
 // Helpful utility functions
 module.exports = function Constructor(currentSettings) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const chalk = require('chalk');
 const fs = require('fs');
 const Fuse = require('fuse.js');
 const path = require('path');
-const ErrorWithoutStack = require('./error-without-stack.js');
+const ErrorWithoutStack = require('./error-without-stack');
 
 // Helpful utility functions
 module.exports = function Constructor(currentSettings) {

--- a/src/waterfall-cli.js
+++ b/src/waterfall-cli.js
@@ -6,10 +6,10 @@ const path = require('path');
 const semver = require('semver');
 const deepmerge = require('deepmerge');
 const defaultSettings = require('./default-settings').default;
-const ErrorWithoutStack = require('./error-without-stack.js');
-const screens = require('./screens.js');
-const utils = require('./utils.js');
-const printPrettyError = require('./print-pretty-error.js');
+const ErrorWithoutStack = require('./error-without-stack');
+const screens = require('./screens');
+const utils = require('./utils');
+const printPrettyError = require('./print-pretty-error');
 
 // Handle exceptions
 process.on('uncaughtException', error => {

--- a/test/print-pretty-error.test.js
+++ b/test/print-pretty-error.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const printPrettyError = require('../dist/print-pretty-error.js');
+const printPrettyError = require('../dist/print-pretty-error');
 const chalk = require('chalk');
 
 // Holders for capturing console.error output

--- a/test/process-arguments.test.js
+++ b/test/process-arguments.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const processArguments = require('../dist/process-arguments.js');
+const processArguments = require('../dist/process-arguments');
 
 // Tests
 describe('#processArguments()', () => {

--- a/test/programs/bad-structure/cli/entry.js
+++ b/test/programs/bad-structure/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-const waterfall = require('../../../../dist/index.js');
+const waterfall = require('../../../../dist/index');
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/es6-imports/cli/entry.js
+++ b/test/programs/es6-imports/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall from '../../../../dist/index.js';
+import waterfall from '../../../../dist/index';
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/es6-imports/cli/entry.js
+++ b/test/programs/es6-imports/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall from '../../../../dist/index';
+import waterfall from '../../../../dist/index.js';
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/pizza-ordering/cli/entry.js
+++ b/test/programs/pizza-ordering/cli/entry.js
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-const waterfall = require('../../../../dist/index.js');
+const waterfall = require('../../../../dist/index');
 
 waterfall.init({
 	verbose: true,

--- a/test/programs/pizza-ordering/cli/list/list.js
+++ b/test/programs/pizza-ordering/cli/list/list.js
@@ -1,5 +1,5 @@
 // Require Waterfall CLI
-const waterfall = require('../../../../../dist/index.js');
+const waterfall = require('../../../../../dist/index');
 
 // Parse command input
 const input = waterfall.command();

--- a/test/programs/typescript/src/entry.ts
+++ b/test/programs/typescript/src/entry.ts
@@ -1,5 +1,5 @@
 // Import and initialize Waterfall CLI
-import waterfall = require('../../../../dist/index.js');
+import waterfall = require('../../../../dist/index');
 
 waterfall.init({
 	verbose: true,

--- a/test/screens.test.js
+++ b/test/screens.test.js
@@ -3,7 +3,7 @@
 
 // Dependencies
 const defaultSettings = require('../dist/default-settings').default;
-const screens = require('../dist/screens.js');
+const screens = require('../dist/screens');
 
 // Remove ANSI formatting
 function removeFormatting(text) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,7 +2,7 @@
 
 // Dependencies
 const defaultSettings = require('../dist/default-settings').default;
-const utils = require('../dist/utils.js');
+const utils = require('../dist/utils');
 
 const settingsBadStructure = {
 	...defaultSettings,


### PR DESCRIPTION
Now all `require` and `import` statements leave off the file extension and let Node.js or the compiler handle that.