### PR TITLE
Change the default for the new version warning to false

### DIFF
--- a/src/default-settings.ts
+++ b/src/default-settings.ts
@@ -9,7 +9,7 @@ const settings: Settings = {
 	arguments: processArguments(process.argv),
 	mainFilename: process.argv[1],
 	newVersionWarning: {
-		enabled: true,
+		enabled: false,
 		installedGlobally: true,
 	},
 	packageFilePath: '../package.json',


### PR DESCRIPTION
Closes #125 

Change the `newVersionWarning.enabled` setting to 'false' instead of `true`.
