### PR TITLE
`onStart` is silently ignored if it is not a function

### DIFF
--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -195,7 +195,7 @@ export function init(customSettings: Partial<Settings>) {
 	);
 
 	// Call onStart() function, if any
-	if (typeof settings.onStart === 'function') {
+	if (settings.onStart) {
 		settings.onStart(inputObject);
 	}
 


### PR DESCRIPTION
Closes #136 

Need to allow a bad `onStart` property value to actually cause a failure.  Currently, it will be silently ignored (not desirable).
