### PR TITLE
Refactor run program

### DIFF
--- a/test/program-bad-onstart.test.js
+++ b/test/program-bad-onstart.test.js
@@ -9,7 +9,7 @@ const entryFile = `${__dirname}/programs/bad-onstart/cli/entry.js`;
 // Tests
 describe('Settings', () => {
 	test('Crashes with invalid `onStart` function', () => {
-		return runProgram(entryFile, 'example')
+		return runProgram('node '+entryFile+' example')
 			.then(() => {
 				throw new Error('This program should not resolve!');
 			})

--- a/test/program-bad-onstart.test.js
+++ b/test/program-bad-onstart.test.js
@@ -11,7 +11,7 @@ describe('Settings', () => {
 	test('Crashes with invalid `onStart` function', () => {
 		return runProgram('node '+entryFile+' example')
 			.then(() => {
-				throw new Error('This program should not resolve!');
+				throw new Error('This program should have crashed!');
 			})
 			.catch(({ error, stderr }) => {
 				expect(error.code).toBe(1);

--- a/test/program-es6-imports.test.js
+++ b/test/program-es6-imports.test.js
@@ -16,7 +16,7 @@ if (semver.lt(semver.clean(process.version), '12.0.0')) {
 	// Tests
 	describe('Built-in abilities', () => {
 		test('Displays version', () => {
-			return runProgram(entryFile, '--version', '--experimental-modules').then(({ stdout }) => {
+			return runProgram('node --experimental-modules '+entryFile+' --version').then(({ stdout }) => {
 				expect(stdout).toContain('es6-imports: 1.2.3');
 			});
 		});

--- a/test/program-pizza-ordering.test.js
+++ b/test/program-pizza-ordering.test.js
@@ -9,31 +9,31 @@ const entryFile = `${__dirname}/programs/pizza-ordering/cli/entry.js`;
 // Tests
 describe('Built-in abilities', () => {
 	test('Displays version', () => {
-		return runProgram(entryFile, '--version').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' --version').then(({ stdout }) => {
 			expect(stdout).toContain('pizza-ordering: 1.2.3');
 		});
 	});
 
 	test('Displays version for a command', () => {
-		return runProgram(entryFile, 'list --version').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' list --version').then(({ stdout }) => {
 			expect(stdout).toContain('pizza-ordering: 1.2.3');
 		});
 	});
 
 	test('Displays help screen', () => {
-		return runProgram(entryFile, '--help').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' --help').then(({ stdout }) => {
 			expect(stdout).toContain('Usage: node entry.js [commands]');
 		});
 	});
 
 	test('Displays help screen for a command', () => {
-		return runProgram(entryFile, 'list --help').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' list --help').then(({ stdout }) => {
 			expect(stdout).toContain('Usage: node entry.js list [flags]');
 		});
 	});
 
 	test('Displays help screen when no arguments', () => {
-		return runProgram(entryFile, '').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' ').then(({ stdout }) => {
 			expect(stdout).toContain('Usage: node entry.js [commands]');
 		});
 	});
@@ -41,7 +41,7 @@ describe('Built-in abilities', () => {
 
 describe('Commands', () => {
 	test('Runs a simple command successfully', () => {
-		return runProgram(entryFile, 'order dine-in').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' order dine-in').then(({ stdout }) => {
 			expect(stdout).toContain('Ordered for dining in');
 		});
 	});
@@ -49,7 +49,7 @@ describe('Commands', () => {
 
 describe('Init settings', () => {
 	test('Calls the `onStart` function', () => {
-		return runProgram(entryFile, 'order dine-in').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' order dine-in').then(({ stdout }) => {
 			expect(stdout).toContain('This is the onStart function');
 		});
 	});

--- a/test/program-typescript.test.js
+++ b/test/program-typescript.test.js
@@ -9,7 +9,7 @@ const entryFile = `${__dirname}/programs/typescript/cli/entry.js`;
 // Tests
 describe('Built-in abilities', () => {
 	test('Displays version', () => {
-		return runProgram(entryFile, '--version').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' --version').then(({ stdout }) => {
 			expect(stdout).toContain('typescript: 1.2.3');
 		});
 	});
@@ -17,7 +17,7 @@ describe('Built-in abilities', () => {
 
 describe('Commands', () => {
 	test('Runs a simple command successfully', () => {
-		return runProgram(entryFile, 'example').then(({ stdout }) => {
+		return runProgram('node '+entryFile+' example').then(({ stdout }) => {
 			expect(stdout).toContain('Ran example command');
 		});
 	});

--- a/test/run-program.js
+++ b/test/run-program.js
@@ -10,15 +10,11 @@ function removeFormatting(text) {
 }
 
 // Test runner
-module.exports = function runProgram(entryFile, programArguments = '', nodeArguments = '') {
+module.exports = function runProgram(command) {
 	// Return a promise
 	return new Promise((resolve, reject) => {
-		// Build the array of all arguments
-		let allArguments = [...nodeArguments.split(' '), entryFile, ...programArguments.split(' ')];
-		allArguments = allArguments.filter(element => element !== '');
-
 		// Launch the program
-		exec('node ' + allArguments.join(' '), (error, stdout, stderr) => {
+		exec(command, (error, stdout, stderr) => {
 			// Handle an issue
 			if (error) {
 				reject({


### PR DESCRIPTION
Now the `runProgram()` function only takes a single argument, a string `command`. No need to pass arrays of different options. This is both more flexible and more intuitive.