### PR TITLE
Compatibility changes for node.js v13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -576,9 +576,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.12.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.4.tgz",
-			"integrity": "sha512-tJUH7//zNZ/539DH4cgZS3NsmW0b9ShDeRBzoCEMCEAlHn5WHUghOfHdycvpo4RCxxEPmQ3WfjDogh+DCCvuSg==",
+			"version": "12.12.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
+			"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
 			"dev": true
 		},
 		"@types/semver": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@types/cli-table": "^0.3.0",
 		"@types/jest": "^24.0.18",
-		"@types/node": "^12.12.4",
+		"@types/node": "^12.12.13",
 		"@types/semver": "^6.0.2",
 		"@typescript-eslint/eslint-plugin": "^2.3.1",
 		"@typescript-eslint/parser": "^2.3.1",

--- a/test/program-es6-imports.test.js
+++ b/test/program-es6-imports.test.js
@@ -16,7 +16,7 @@ if (semver.lt(semver.clean(process.version), '12.0.0')) {
 	// Tests
 	describe('Built-in abilities', () => {
 		test('Displays version', () => {
-			return runProgram(`node --experimental-modules ${entryFile} --version`).then(({ stdout }) => {
+			return runProgram(`node ${entryFile} --version`).then(({ stdout }) => {
 				expect(stdout).toContain('es6-imports: 1.2.3');
 			});
 		});

--- a/test/program-es6-imports.test.js
+++ b/test/program-es6-imports.test.js
@@ -8,8 +8,8 @@ const semver = require('semver');
 const entryFile = `${__dirname}/programs/es6-imports/cli/entry.js`;
 
 // Don't run the normal tests if older than Node.js version 12
-if (semver.lt(semver.clean(process.version), '12.0.0')) {
-	test('Tests disabled on Node.js versions older than v12', () => {
+if (semver.lt(semver.clean(process.version), '13.2.0')) {
+	test('Tests disabled on Node.js versions older than v13.2.0', () => {
 		expect(true).toBe(true);
 	});
 } else {

--- a/test/program-global-bin.test.js
+++ b/test/program-global-bin.test.js
@@ -19,7 +19,7 @@ beforeAll(() => {
 			resolve();
 		});
 	});
-});
+}, 20000);
 
 // Tests
 describe('Built-in abilities', () => {
@@ -42,4 +42,4 @@ afterAll(() => {
 			resolve();
 		});
 	});
-});
+}, 20000);


### PR DESCRIPTION
Remove the `--experimental-modules` flag.

Local testing shows that there is now insufficient time to perform the  `beforeAll()` and `afterAll()` tasks within the default timeout of 5s for the `global-bin` test.  Local testing shows 13 seconds are needed just for the `npm link` portion.