### PR TITLE
Greenkeeper/@types/node 12.12.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -576,9 +576,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.12.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-			"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+			"version": "12.12.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
+			"integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==",
 			"dev": true
 		},
 		"@types/semver": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"devDependencies": {
 		"@types/cli-table": "^0.3.0",
 		"@types/jest": "^24.0.18",
-		"@types/node": "^12.12.13",
+		"@types/node": "^12.12.17",
 		"@types/semver": "^6.0.2",
 		"@typescript-eslint/eslint-plugin": "^2.3.1",
 		"@typescript-eslint/parser": "^2.3.1",


### PR DESCRIPTION
This tests ok for me.  I saw in the log files that there was a notice:

```
$ npm ci 
npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! 
npm ERR! Invalid: lock file's @types/node@12.12.14 does not satisfy @types/node@^12.12.17
npm ERR! 
```

Removing the node_modules folder and doing `npm install` seems to have gotten things back in sync, and tests (locally) are passing.
