### PR TITLE
Ensure chalk emits colors

### DIFF
--- a/src/chalk.ts
+++ b/src/chalk.ts
@@ -1,6 +1,5 @@
 // Imports
 import * as chalk from 'chalk';
 
-
 // Export chalk with color support enabled
 export default new chalk.Instance({ level: 3 });

--- a/src/chalk.ts
+++ b/src/chalk.ts
@@ -1,0 +1,6 @@
+// Imports
+import * as chalk from 'chalk';
+
+
+// Export chalk with color support enabled
+export default new chalk.Instance({ level: 3 });

--- a/src/print-pretty-error.ts
+++ b/src/print-pretty-error.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import chalk from 'chalk';
+import chalk from './chalk';
 
 // Print a pretty error message
 export default function printPrettyError(message: string) {

--- a/src/screens.ts
+++ b/src/screens.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import chalk from 'chalk';
+import chalk from './chalk';
 import Table from 'cli-table';
 import { Settings } from './types';
 import utils from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import chalk from 'chalk';
+import chalk from './chalk';
 import fs from 'fs';
 import path from 'path';
 import Fuse from 'fuse.js';

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -1,5 +1,5 @@
 // Dependencies
-import chalk from 'chalk';
+import chalk from './chalk';
 import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';

--- a/test/print-pretty-error.test.ts
+++ b/test/print-pretty-error.test.ts
@@ -2,7 +2,7 @@
 
 // Dependencies
 const printPrettyError = require('../dist/print-pretty-error').default;
-const chalk = require('chalk');
+const chalk = require('../dist/chalk').default;
 
 // Holders for capturing console.error output
 let spy;


### PR DESCRIPTION
Closes #247 

This demonstrates that the sub-shelled use of Spark now emits the `waterfall.error()` message text with coloring applied:

<img width="802" alt="Image 2020-06-01 at 1 54 02 PM" src="https://user-images.githubusercontent.com/10079005/83444691-5ecb4300-a411-11ea-86a3-15ec2833e14f.png">

The highlighted section is emitted by the `waterfall.error()`, and previously did not show the inverted text, nor the red color.
