### PR TITLE
Flush stdout before error outputs to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ _**Heads up!** This proof-of-concept is only used internally right now; however,
 
 Notes:
 
-The `error()` function, if used from an async context as `await waterfall.error('Message text goes here');`, an attempt is made to wait for buffered stdout content _before_ emitting the error message on stderr, and calling `exit()` to terminate the application.  Use in synchronous contexts will likely not see this happen because Promise resolution will not actually be waited for.
+The `error()` function, if used in an async context like `await waterfall.error('Message text goes here');`, will attempt to wait for buffered stdout content to flush _before_ emitting the error message on stderr and terminating the application. Using the `error()` function in a synchronous context, though, will likely not see this happen because the code won't wait for the `Promise` to resolve.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Effortlessly create powerful, thoughtfully-organized CLIs with Node.js, using an
 
 _**Heads up!** This proof-of-concept is only used internally right now; however, we may flesh out Waterfall CLI as a fully-capable open source project in the future._
 
-Notes:
+### Notes for future documentation:
 
 The `error()` function, if used in an async context like `await waterfall.error('Message text goes here');`, will attempt to wait for buffered stdout content to flush _before_ emitting the error message on stderr and terminating the application. Using the `error()` function in a synchronous context, though, will likely not see this happen because the code won't wait for the `Promise` to resolve.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Effortlessly create powerful, thoughtfully-organized CLIs with Node.js, using an intuitive cascading design.
 
 _**Heads up!** This proof-of-concept is only used internally right now; however, we may flesh out Waterfall CLI as a fully-capable open source project in the future._
+
+Notes:
+
+The `error()` function, if used from an async context as `await waterfall.error('Message text goes here');`, an attempt is made to wait for buffered stdout content _before_ emitting the error message on stderr, and calling `exit()` to terminate the application.  Use in synchronous contexts will likely not see this happen because Promise resolution will not actually be waited for.

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -220,7 +220,7 @@ export function parse() {
 // A helper function provided to commands to keep error messages consistent
 export async function error(message: string) {
 	// Allow stdout to flush before proceeding
-	await new Promise<void>((resolve) => {
+	await new Promise<Error | undefined>((resolve) => {
 		process.stdout.write('', resolve);
 	});
 

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -218,7 +218,17 @@ export function parse() {
 }
 
 // A helper function provided to commands to keep error messages consistent
-export function error(message: string) {
+export async function error(message: string) {
+	// Allow stdout to flush before proceeding
+	await new Promise<void>((resolve) => {
+		process.stdout.write('', () => {
+			resolve();
+		});
+	});
+	
+	// Emit error message
 	printPrettyError(message);
+	
+	// Exit
 	process.exit(255);
 }

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -225,10 +225,10 @@ export async function error(message: string) {
 			resolve();
 		});
 	});
-	
+
 	// Emit error message
 	printPrettyError(message);
-	
+
 	// Exit
 	process.exit(255);
 }

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -221,9 +221,7 @@ export function parse() {
 export async function error(message: string) {
 	// Allow stdout to flush before proceeding
 	await new Promise<void>((resolve) => {
-		process.stdout.write('', () => {
-			resolve();
-		});
+		process.stdout.write('', resolve);
 	});
 
 	// Emit error message


### PR DESCRIPTION
Closes #258 

This makes it possible to use `await waterfall.error('message');` and have stdout content that may not yet have flushed, be emitted before proceeding to emit the message on stderr, then `exit()`.
