### PR TITLE
Silence complaints about missing license settings

### DIFF
--- a/test/programs/bad-onstart/package.json
+++ b/test/programs/bad-onstart/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "bad-onstart",
 	"version": "1.2.3",
+	"license": "MIT",
 	"dependencies": {
 		"waterfall-cli": "file:../../../"
 	}

--- a/test/programs/bad-structure/package.json
+++ b/test/programs/bad-structure/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "bad-structure",
 	"version": "1.2.3",
+	"license": "MIT",
 	"dependencies": {
 		"waterfall-cli": "file:../../../"
 	}

--- a/test/programs/es6-imports/package.json
+++ b/test/programs/es6-imports/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "es6-imports",
 	"version": "1.2.3",
+	"license": "MIT",
 	"type": "module",
 	"dependencies": {
 		"waterfall-cli": "file:../../../"

--- a/test/programs/global-bin/package.json
+++ b/test/programs/global-bin/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "global-bin",
 	"version": "1.2.3",
+	"license": "MIT",
 	"bin": {
 		"global-bin": "./cli/entry.js"
 	},

--- a/test/programs/pizza-ordering/package.json
+++ b/test/programs/pizza-ordering/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "pizza-ordering",
 	"version": "1.2.3",
+	"license": "MIT",
 	"dependencies": {
 		"waterfall-cli": "file:../../../"
 	}

--- a/test/programs/typescript/package.json
+++ b/test/programs/typescript/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "typescript",
 	"version": "1.2.3",
+	"license": "MIT",
 	"scripts": {
 		"compile": "rm -rf cli/ && tsc"
 	},


### PR DESCRIPTION
closes https://github.com/sparksuite/waterfall-cli/issues/275

I notice that when running `yarn test`, there are a number of complaints that appear, regarding the `project.json` not having a `license` defined.

So, lets silence the complaints by providing a license definition in each case.

