### PR TITLE
Add support for capturing passthrough arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,12 +31,14 @@ export interface CommandSpec {
 		};
 	};
 	executeOnCascade?: true;
+	passThrough?: true;
 }
 
 export interface InputObject {
 	command: string;
 	data?: string | number;
-	[index: string]: boolean | string | number | undefined;
+	passThrough?: string[];
+	[index: string]: boolean | string | string[] | number | undefined;
 }
 
 export interface OrganizedArguments {
@@ -45,6 +47,7 @@ export interface OrganizedArguments {
 	flags: string[];
 	options: string[];
 	values: (string | number)[];
+	passThrough?: string[];
 }
 
 export interface Settings {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -451,7 +451,7 @@ export default function utils(currentSettings: Settings) {
 			if (organizedArguments.passThrough) {
 				inputObject.passThrough = organizedArguments.passThrough;
 			}
-			
+
 			// Return
 			return inputObject;
 		},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,10 @@ export default function utils(currentSettings: Settings) {
 					});
 				}
 
+				if (spec.passThrough) {
+					mergedSpec.passThrough = true;
+				}
+
 				if (index === pieces.length - 1) {
 					mergedSpec.description = spec.description;
 					mergedSpec.data = spec.data;
@@ -122,6 +126,7 @@ export default function utils(currentSettings: Settings) {
 			let nextValueType: string | null = null;
 			let nextValueAccepts: string[] | null = null;
 			let reachedData = false;
+			let reachedPassThrough = false;
 
 			// Loop over every command
 			let currentPathPrefix = path.dirname(settings.mainFilename);
@@ -129,6 +134,18 @@ export default function utils(currentSettings: Settings) {
 			for (const argument of settings.arguments) {
 				// Verbose output
 				utils(settings).verboseLog(`Inspecting argument: ${argument}`);
+
+				// Collect pass-through arguments
+				if (reachedPassThrough) {
+					// Initialize if needed
+					if (!organizedArguments.passThrough) {
+						organizedArguments.passThrough = [];
+					}
+
+					// Store pass-through
+					organizedArguments.passThrough.push(argument);
+					continue;
+				}
 
 				// Skip option values
 				if (nextIsOptionValue) {
@@ -188,6 +205,18 @@ export default function utils(currentSettings: Settings) {
 					}
 
 					// Skip further processing
+					continue;
+				}
+
+				// Detect pass-through indication
+				if (argument === '--') {
+					// Error if this command does not accept pass-through arguments
+					if (!mergedSpec.passThrough) {
+						throw new ErrorWithoutStack(`Unrecognized argument: ${argument}`);
+					}
+
+					// Begin collecting pass-through arguments
+					reachedPassThrough = true;
 					continue;
 				}
 
@@ -418,6 +447,11 @@ export default function utils(currentSettings: Settings) {
 			// Store command
 			inputObject.command = organizedArguments.command;
 
+			// Store pass-through
+			if (organizedArguments.passThrough) {
+				inputObject.passThrough = organizedArguments.passThrough;
+			}
+			
 			// Return
 			return inputObject;
 		},

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -8,7 +8,7 @@ import deepmerge from 'deepmerge';
 import defaultSettings from './default-settings';
 import ErrorWithoutStack from './error-without-stack';
 import screens from './screens';
-import { Settings } from './types';
+import { Settings, InputObject } from './types';
 import utils from './utils';
 import printPrettyError from './print-pretty-error';
 
@@ -214,7 +214,7 @@ export function init(customSettings: Partial<Settings>) {
 
 // The function used to kick off commands
 export function parse() {
-	return JSON.parse(process.argv[2]);
+	return JSON.parse(process.argv[2]) as InputObject;
 }
 
 // A helper function provided to commands to keep error messages consistent

--- a/src/waterfall-cli.ts
+++ b/src/waterfall-cli.ts
@@ -8,7 +8,7 @@ import deepmerge from 'deepmerge';
 import defaultSettings from './default-settings';
 import ErrorWithoutStack from './error-without-stack';
 import screens from './screens';
-import { Settings, InputObject } from './types';
+import { Settings } from './types';
 import utils from './utils';
 import printPrettyError from './print-pretty-error';
 
@@ -214,7 +214,7 @@ export function init(customSettings: Partial<Settings>) {
 
 // The function used to kick off commands
 export function parse() {
-	return JSON.parse(process.argv[2]) as InputObject;
+	return JSON.parse(process.argv[2]);
 }
 
 // A helper function provided to commands to keep error messages consistent

--- a/test/programs/pizza-ordering/cli/order/to-go/to-go.spec.js
+++ b/test/programs/pizza-ordering/cli/order/to-go/to-go.spec.js
@@ -10,4 +10,5 @@ module.exports = {
 			type: 'fake',
 		},
 	},
+	passThrough: true,
 };

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -766,7 +766,7 @@ describe('#organizeArguments()', () => {
 			command: 'order to-go',
 			flags: [],
 			options: [],
-			passThrough: ['--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
+			passThrough: ['--pass-through-flag', 'pass-through-option=value', 'pass-through-data'],
 			values: [],
 		});
 	});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -748,7 +748,7 @@ describe('#organizeArguments()', () => {
 	test('Complains about unexpected pass-through arguments ', () => {
 		const settings = {
 			...settingsPizzaOrdering,
-			arguments: ['order', 'dine-in', '--', '--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+			arguments: ['order', 'dine-in', '--', '--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
 		};
 
 		expect(() => {
@@ -759,14 +759,14 @@ describe('#organizeArguments()', () => {
 	test('Handles having pass-through arguments', () => {
 		const settings = {
 			...settingsPizzaOrdering,
-			arguments: ['order', 'to-go', '--', '--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+			arguments: ['order', 'to-go', '--', '--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
 		};
 
 		expect(utils(settings).organizeArguments()).toStrictEqual({
 			command: 'order to-go',
 			flags: [],
 			options: [],
-			passThrough: ['--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+			passThrough: ['--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
 			values: [],
 		});
 	});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -759,7 +759,7 @@ describe('#organizeArguments()', () => {
 	test('Handles having pass-through arguments', () => {
 		const settings = {
 			...settingsPizzaOrdering,
-			arguments: ['order', 'to-go', '--', '--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
+			arguments: ['order', 'to-go', '--', '--pass-through-flag', 'pass-through-option=value', 'pass-through-data'],
 		};
 
 		expect(utils(settings).organizeArguments()).toStrictEqual({

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -752,7 +752,7 @@ describe('#organizeArguments()', () => {
 		};
 
 		expect(() => {
-			utils(settings).organizeArguments()
+			utils(settings).organizeArguments();
 		}).toThrow();
 	});
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -744,6 +744,32 @@ describe('#organizeArguments()', () => {
 			utils(settings).organizeArguments();
 		}).toThrow();
 	});
+
+	test('Complains about unexpected pass-through arguments ', () => {
+		const settings = {
+			...settingsPizzaOrdering,
+			arguments: ['order', 'dine-in', '--', '--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+		};
+
+		expect(() => {
+			utils(settings).organizeArguments()
+		}).toThrow();
+	});
+
+	test('Handles having pass-through arguments', () => {
+		const settings = {
+			...settingsPizzaOrdering,
+			arguments: ['order', 'to-go', '--', '--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+		};
+
+		expect(utils(settings).organizeArguments()).toStrictEqual({
+			command: 'order to-go',
+			flags: [],
+			options: [],
+			passThrough: ['--passThrough-flag', 'passThroughArgument1', 'passThroughArgument2'],
+			values: [],
+		});
+	});
 });
 
 describe('#constructInputObject()', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -748,7 +748,7 @@ describe('#organizeArguments()', () => {
 	test('Complains about unexpected pass-through arguments ', () => {
 		const settings = {
 			...settingsPizzaOrdering,
-			arguments: ['order', 'dine-in', '--', '--pass-through-flag', 'pass-through-option=true', 'pass-through-data'],
+			arguments: ['order', 'dine-in', '--', '--pass-through-flag', 'pass-through-option=value', 'pass-through-data'],
 		};
 
 		expect(() => {


### PR DESCRIPTION
closes https://github.com/sparksuite/waterfall-cli/issues/276

Adds to the `.spec.ts` file, the optional `passThrough: true` option, and, to the `InputObject`, an optional array (`passThrough`) holding the captured arguments being passed through.

The passThrough items are in the same sequence as provided on the command line.

This allows users to do something like:

`utilCommand --option one -- --extra things here`

The `--extra things here` will appear in the response object from `waterfall.parse()` as: `.passThrough: [ '--extra', 'things', 'here']` and it's up to the code then, to do whatever is appropriate.

If support for passThrough is not enabled, and it's used, the user will be provided with an error message informing them of this situation.

Here is a screen shot of how a client app, not having the `passThrough` enabled for the 'run' command indicates improper usage:

<img width="546" alt="Image 2020-07-24 at 2 27 50 PM" src="https://user-images.githubusercontent.com/10079005/88428114-de461480-cdb9-11ea-88a2-687c0a696294.png">
