### PR TITLE
Add help indication of pass through support

### DIFF
--- a/src/screens.ts
+++ b/src/screens.ts
@@ -74,6 +74,7 @@ export default function screens(currentSettings: Settings) {
 			const hasOptions = !!Object.entries(mergedSpec.options).length;
 			const allowsData = typeof mergedSpec.data === 'object';
 			const hasCommands = !!commands.length;
+			const allowsPassThrough = mergedSpec.passThrough;
 
 			// Output description
 			if (mergedSpec.description) {
@@ -88,6 +89,7 @@ export default function screens(currentSettings: Settings) {
 			usageLine += chalk.gray(hasFlags ? ' [flags]' : '');
 			usageLine += chalk.gray(hasOptions ? ' [options]' : '');
 			usageLine += chalk.gray(allowsData ? ' [data]' : '');
+			usageLine += chalk.gray(allowsPassThrough ? ' -- [pass-through arguments]' : '');
 
 			outputString += `${usageLine}\n`;
 
@@ -206,6 +208,15 @@ export default function screens(currentSettings: Settings) {
 
 				// Print
 				outputString += `  ${fullDescription}\n`;
+			}
+
+			// Handle pass-through
+			if (allowsPassThrough) {
+				// Print header
+				outputString += '\nPASS-THROUGH:\n';
+
+				// Full description
+				outputString += '  Arguments after ‘--’ will be passed through to an underlying command\n';
 			}
 
 			// Add spacing after


### PR DESCRIPTION
Closes #280 

When pass-through is supported, adds to the '--help' output to indicate it's available.

<img width="1361" alt="Image 2020-07-27 at 6 55 30 PM" src="https://user-images.githubusercontent.com/10079005/88603702-43f50380-d03b-11ea-9c8e-1dedb1cd3475.png">
