### PR TITLE
Use imports instead of requires in tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,8 +10,4 @@ module.exports = {
 		],
 		'@babel/preset-typescript',
 	],
-	plugins: [
-		'@babel/plugin-proposal-nullish-coalescing-operator', // TODO: Will become unnecessary soon: https://github.com/babel/babel/issues/10690
-		'@babel/plugin-proposal-optional-chaining', // TODO: Will become unnecessary soon: https://github.com/babel/babel/issues/10690
-	],
 };

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.7.5",
-		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
-		"@babel/plugin-proposal-optional-chaining": "^7.7.5",
 		"@babel/preset-env": "^7.7.6",
 		"@babel/preset-typescript": "^7.7.4",
 		"@types/cli-table": "^0.3.0",
@@ -48,6 +46,7 @@
 		"@types/semver": "^7.1.0",
 		"@typescript-eslint/eslint-plugin": "^2.23.0",
 		"@typescript-eslint/parser": "^2.23.0",
+		"babel-jest": "^26.6.3",
 		"eslint": "^6.4.0",
 		"eslint-config-prettier": "^6.3.0",
 		"eslint-plugin-import": "^2.18.2",

--- a/test/print-pretty-error.test.ts
+++ b/test/print-pretty-error.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
 // Dependencies
-const printPrettyError = require('../dist/print-pretty-error').default;
-const chalk = require('../dist/chalk').default;
+import printPrettyError from '../src/print-pretty-error';
+import chalk from '../src/chalk';
 
 // Holders for capturing console.error output
 let spy;

--- a/test/process-arguments.test.ts
+++ b/test/process-arguments.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const processArguments = require('../dist/process-arguments').default;
+import processArguments from '../src/process-arguments';
 
 // Tests
 describe('#processArguments()', () => {

--- a/test/program-bad-onstart.test.ts
+++ b/test/program-bad-onstart.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const runProgram = require('./run-program');
+import runProgram from './run-program';
 
 // Initialize
 const entryFile = `${__dirname}/programs/bad-onstart/cli/entry.js`;

--- a/test/program-es6-imports.test.ts
+++ b/test/program-es6-imports.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
 // Dependencies
-const runProgram = require('./run-program');
-const semver = require('semver');
+import runProgram from './run-program';
+import semver from 'semver';
 
 // Initialize
 const entryFile = `${__dirname}/programs/es6-imports/cli/entry.js`;

--- a/test/program-global-bin.test.ts
+++ b/test/program-global-bin.test.ts
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 
 // Dependencies
-const runProgram = require('./run-program');
-const path = require('path');
-const { exec } = require('child_process');
+import runProgram from './run-program';
+import path from 'path';
+import { exec } from 'child_process';
 
 // Link this program
 beforeAll(() => {

--- a/test/program-pizza-ordering.test.ts
+++ b/test/program-pizza-ordering.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const runProgram = require('./run-program');
+import runProgram from './run-program';
 
 // Initialize
 const entryFile = `${__dirname}/programs/pizza-ordering/cli/entry.js`;

--- a/test/program-typescript.test.ts
+++ b/test/program-typescript.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 // Dependencies
-const runProgram = require('./run-program');
+import runProgram from './run-program';
 
 // Initialize
 const entryFile = `${__dirname}/programs/typescript/cli/entry.js`;

--- a/test/run-program.ts
+++ b/test/run-program.ts
@@ -10,7 +10,7 @@ function removeFormatting(text) {
 }
 
 // Test runner
-export default function runProgram(command: string): Promise<{ stdout: string; stderr: string; }> {
+export default function runProgram(command: string): Promise<{ stdout: string; stderr: string }> {
 	// Return a promise
 	return new Promise((resolve, reject) => {
 		// Launch the program
@@ -33,4 +33,4 @@ export default function runProgram(command: string): Promise<{ stdout: string; s
 			});
 		});
 	});
-};
+}

--- a/test/run-program.ts
+++ b/test/run-program.ts
@@ -1,5 +1,5 @@
 // Dependencies
-const { exec } = require('child_process');
+import { exec } from 'child_process';
 
 // Remove ANSI formatting
 function removeFormatting(text) {
@@ -10,7 +10,7 @@ function removeFormatting(text) {
 }
 
 // Test runner
-module.exports = function runProgram(command) {
+export default function runProgram(command: string): Promise<{ stdout: string; stderr: string; }> {
 	// Return a promise
 	return new Promise((resolve, reject) => {
 		// Launch the program

--- a/test/screens.test.ts
+++ b/test/screens.test.ts
@@ -2,8 +2,8 @@
 /* eslint no-control-regex: "off" */
 
 // Dependencies
-const defaultSettings = require('../dist/default-settings').default;
-const screens = require('../dist/screens').default;
+import defaultSettings from '../src/default-settings';
+import screens from '../src/screens';
 
 // Remove ANSI formatting
 function removeFormatting(text) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
 // Dependencies
-const defaultSettings = require('../dist/default-settings').default;
-const utils = require('../dist/utils').default;
+import defaultSettings from '../src/default-settings';
+import utils from '../src/utils';
 
 const settingsBadStructure = {
 	...defaultSettings,

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,7 +336,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.7.4":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
   integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
@@ -369,7 +369,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.7", "@babel/plugin-proposal-optional-chaining@^7.7.5":
+"@babel/plugin-proposal-optional-chaining@^7.12.7":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
   integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==


### PR DESCRIPTION
This replaces the use of `require()` in test files. It also removes some now-outdated Babel plugins.