### PR TITLE
Stricter types for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -8,7 +8,7 @@ import getOrganizedArguments from '../utils/get-organized-arguments.js';
 import printPrettyError from '../utils/print-pretty-error.js';
 import verboseLog from '../utils/verbose-log.js';
 import path from 'path';
-import getCommandSpec from '../utils/get-command-spec.js';
+import getCommandSpec, { EmptyCommandInput } from '../utils/get-command-spec.js';
 import constructInputObject from '../utils/construct-input-object.js';
 import chalk from '../utils/chalk.js';
 import CommandFunction from '../types/command-function.js';
@@ -101,12 +101,14 @@ export default async function init(customConfig: Partial<Config>): Promise<void>
 		// Run each command path sequentially, starting with the first
 		for (const commandPath of commandPaths) {
 			// Initialize
-			let command: CommandFunction | undefined = undefined;
+			let command: CommandFunction<EmptyCommandInput> | undefined = undefined;
 			const truncatedPath = commandPath.replace(`${path.dirname(context.entryFile)}/`, '');
 
 			// Import it within a try/catch
 			try {
-				const importedCommand = (await import(commandPath)) as { default: CommandFunction } | CommandFunction;
+				const importedCommand = (await import(commandPath)) as
+					| { default: CommandFunction<EmptyCommandInput> }
+					| CommandFunction<EmptyCommandInput>;
 				command = 'default' in importedCommand ? importedCommand.default : importedCommand;
 			} catch (error: unknown) {
 				// Let outer try/catch handle printable errors

--- a/src/screens/help.ts
+++ b/src/screens/help.ts
@@ -47,8 +47,8 @@ export default async function helpScreen(): Promise<string> {
 	const mergedSpec = await getMergedSpec(organizedArguments.command);
 
 	// Determine if certain features are available
-	const hasFlags = Boolean(Object.entries(mergedSpec.flags).length);
-	const hasOptions = Boolean(Object.entries(mergedSpec.options).length);
+	const hasFlags = Boolean(Object.entries(mergedSpec.flags ?? {}).length);
+	const hasOptions = Boolean(Object.entries(mergedSpec.options ?? {}).length);
 	const allowsData = typeof mergedSpec.data === 'object';
 	const hasCommands = Boolean(commands.length);
 	const allowsPassThrough = mergedSpec.acceptsPassThroughArgs;
@@ -101,7 +101,7 @@ export default async function helpScreen(): Promise<string> {
 		table.push(['\nFLAGS:']);
 
 		// List flags
-		Object.entries(mergedSpec.flags).forEach(([flag, details]) => {
+		Object.entries(mergedSpec.flags ?? {}).forEach(([flag, details]) => {
 			table.push([
 				`  --${flag}${details.shorthand ? `, -${details.shorthand}` : ''}`,
 				`${details.description ? `${details.description}` : ''}`,
@@ -115,7 +115,7 @@ export default async function helpScreen(): Promise<string> {
 		table.push(['\nOPTIONS:']);
 
 		// List options
-		Object.entries(mergedSpec.options).forEach(([option, details]) => {
+		Object.entries(mergedSpec.options ?? {}).forEach(([option, details]) => {
 			// Form full description
 			let fullDescription = '';
 

--- a/src/types/command-function.ts
+++ b/src/types/command-function.ts
@@ -2,6 +2,6 @@
 import { InputObject } from '../utils/construct-input-object.js';
 import { CommandInput, EmptyCommandInput } from '../utils/get-command-spec.js';
 
-// Export type
+/** Describes a function that's executed when a command is run */
 type CommandFunction<Input extends CommandInput = EmptyCommandInput> = (input: InputObject<Input>) => Promise<void>;
 export default CommandFunction;

--- a/src/types/command-function.ts
+++ b/src/types/command-function.ts
@@ -1,6 +1,7 @@
 // Imports
 import { InputObject } from '../utils/construct-input-object.js';
+import { CommandInput, EmptyCommandInput } from '../utils/get-command-spec.js';
 
 // Export type
-type CommandFunction = (input: InputObject) => Promise<void>;
+type CommandFunction<Input extends CommandInput = EmptyCommandInput> = (input: InputObject<Input>) => Promise<void>;
 export default CommandFunction;

--- a/src/types/exclude-matching-properties.ts
+++ b/src/types/exclude-matching-properties.ts
@@ -1,0 +1,8 @@
+export interface ExcludeMe {
+	excludeMe: true;
+}
+
+export type OmitExcludeMeProperties<T> = Pick<
+	T,
+	{ [K in keyof T]: NonNullable<T[K]> extends ExcludeMe ? never : K }[keyof T]
+>;

--- a/src/utils/construct-input-object.test.ts
+++ b/src/utils/construct-input-object.test.ts
@@ -24,14 +24,18 @@ describe('#constructInputObject()', () => {
 		expect(await constructInputObject()).toStrictEqual({
 			command: 'list',
 			data: 'toppings',
-			deliveryZipCode: '55555',
-			help: false,
-			limit: undefined,
-			maxPrice: undefined,
-			quiet: true,
-			sort: 'popularity',
-			vegetarian: true,
-			version: false,
+			options: {
+				deliveryZipCode: '55555',
+				limit: undefined,
+				maxPrice: undefined,
+				sort: 'popularity',
+			},
+			flags: {
+				help: false,
+				quiet: true,
+				vegetarian: true,
+				version: false,
+			},
 		});
 	});
 

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -4,20 +4,28 @@ import path from 'path';
 import chalk from './chalk.js';
 import { PrintableError } from './errors.js';
 
-// Define what a command spec looks like
-export interface CommandSpec {
-	/** A description of this command, to be shown on help screens. */
-	description?: string;
-
-	/** Whether to execute this command before executing commands farther down in the file tree. */
-	executeOnCascade?: true;
-
-	/** Whether this command accepts pass-through arguments (arguments that follow ` -- `). Pass-through arguments are intended to be handed off to another program being executed by this command. */
-	acceptsPassThroughArgs?: true;
-
-	/** Permitted boolean arguments. */
+// Define what command input looks like
+export interface CommandInput {
 	flags?: {
-		[flag: string]: {
+		[flag: string]: boolean;
+	};
+	options?: {
+		[option: string]: string | number;
+	};
+	data?: string | number;
+}
+
+// Helper types
+export type AnyCommandInput = Required<CommandInput>;
+export type EmptyCommandInput = {
+	[Key in keyof AnyCommandInput]: undefined;
+};
+
+// Define what a command spec looks like
+interface RequiredFlags<Flags extends NonNullable<CommandInput['flags']>> {
+	/** Permitted boolean arguments. */
+	flags: {
+		[Flag in keyof Flags]: {
 			/** A description of this flag, to be shown on help screens. */
 			description?: string;
 
@@ -28,10 +36,12 @@ export interface CommandSpec {
 			shorthand?: string;
 		};
 	};
+}
 
+interface RequiredOptions<Options extends NonNullable<CommandInput['options']>> {
 	/** Permitted key/value arguments. */
-	options?: {
-		[option: string]: {
+	options: {
+		[Option in keyof Options]: {
 			/** A description of this option, to be shown on help screens. */
 			description?: string;
 
@@ -51,9 +61,11 @@ export interface CommandSpec {
 			accepts?: string[];
 		};
 	};
+}
 
+interface RequiredData<Data extends NonNullable<CommandInput['data']>> {
 	/** Details about what kind of data this command accepts. Any object (even an empty one) permits data. The keys inside this object provide details about the data. */
-	data?: {
+	data: {
 		/** A description of what kind of data should be provided, to be shown on help screens. */
 		description?: string;
 
@@ -61,7 +73,7 @@ export interface CommandSpec {
 		required?: true;
 
 		/** What type of data should be provided. Invalid data will be rejected. */
-		type?: 'integer' | 'float';
+		type?: number extends Data ? 'integer' | 'float' : never; // TODO: this needs improving
 
 		/** A finite array of acceptable data strings. Invalid data will be rejected. */
 		accepts?: string[];
@@ -71,8 +83,38 @@ export interface CommandSpec {
 	};
 }
 
+interface BaseCommandSpec {
+	/** A description of this command, to be shown on help screens. */
+	description?: string;
+
+	/** Whether to execute this command before executing commands farther down in the file tree. */
+	executeOnCascade?: true;
+
+	/** Whether this command accepts pass-through arguments (arguments that follow ` -- `). Pass-through arguments are intended to be handed off to another program being executed by this command. */
+	acceptsPassThroughArgs?: true;
+}
+
+export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = undefined extends Input['flags']
+	? undefined extends Input['options']
+		? undefined extends Input['data']
+			? BaseCommandSpec
+			: BaseCommandSpec & RequiredData<NonNullable<Input['data']>>
+		: undefined extends Input['data']
+		? BaseCommandSpec & RequiredOptions<NonNullable<Input['options']>>
+		: BaseCommandSpec & RequiredOptions<NonNullable<Input['options']>> & RequiredData<NonNullable<Input['data']>>
+	: undefined extends Input['options']
+	? undefined extends Input['data']
+		? BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>>
+		: BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>> & RequiredData<NonNullable<Input['data']>>
+	: undefined extends Input['data']
+	? BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>> & RequiredOptions<NonNullable<Input['options']>>
+	: BaseCommandSpec &
+			RequiredFlags<NonNullable<Input['flags']>> &
+			RequiredOptions<NonNullable<Input['options']>> &
+			RequiredData<NonNullable<Input['data']>>;
+
 /** Get the parsed command spec from a particular directory */
-export default async function getCommandSpec(directory: string): Promise<CommandSpec> {
+export default async function getCommandSpec(directory: string): Promise<Partial<CommandSpec<AnyCommandInput>>> {
 	// Error if directory does not exist
 	if (!fs.existsSync(directory)) {
 		throw new Error(`Directory does not exist: ${directory}`);
@@ -104,7 +146,9 @@ export default async function getCommandSpec(directory: string): Promise<Command
 
 	// Return
 	try {
-		const spec = (await import(specFilePath)) as { default: CommandSpec } | CommandSpec;
+		const spec = (await import(specFilePath)) as
+			| { default: CommandSpec<EmptyCommandInput> }
+			| CommandSpec<EmptyCommandInput>;
 		return 'default' in spec ? spec.default : spec;
 	} catch (error) {
 		throw new PrintableError(

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from './chalk.js';
 import { PrintableError } from './errors.js';
+import { ExcludeMe, OmitExcludeMeProperties } from '../types/exclude-matching-properties.js';
 
 // Define what command input looks like
 export interface CommandInput {
@@ -10,80 +11,19 @@ export interface CommandInput {
 		[flag: string]: boolean;
 	};
 	options?: {
-		[option: string]: string | number;
+		[option: string]: string | string[] | number | number[];
 	};
-	data?: string | number;
+	data?: string | string[] | number | number[];
+	acceptsPassThroughArgs?: true;
 }
 
 // Helper types
-export type AnyCommandInput = Required<CommandInput>;
 export type EmptyCommandInput = {
-	[Key in keyof AnyCommandInput]: undefined;
+	[Key in keyof Required<CommandInput>]: undefined;
 };
 
-// Define what a command spec looks like
-interface RequiredFlags<Flags extends NonNullable<CommandInput['flags']>> {
-	/** Permitted boolean arguments. */
-	flags: {
-		[Flag in keyof Flags]: {
-			/** A description of this flag, to be shown on help screens. */
-			description?: string;
-
-			/** Whether this flag also applies to commands farther down in the file tree. */
-			cascades?: true;
-
-			/** A single-character that could be used instead of the full flag name. */
-			shorthand?: string;
-		};
-	};
-}
-
-interface RequiredOptions<Options extends NonNullable<CommandInput['options']>> {
-	/** Permitted key/value arguments. */
-	options: {
-		[Option in keyof Options]: {
-			/** A description of this option, to be shown on help screens. */
-			description?: string;
-
-			/** Whether this option also applies to commands farther down in the file tree. */
-			cascades?: true;
-
-			/** A single-character that could be used instead of the full option name. */
-			shorthand?: string;
-
-			/** Whether this option must be provided with this command. */
-			required?: true;
-
-			/** What type of value should be provided. Invalid values will be rejected. */
-			type?: 'integer' | 'float';
-
-			/** A finite array of acceptable value strings. Invalid values will be rejected. */
-			accepts?: string[];
-		};
-	};
-}
-
-interface RequiredData<Data extends NonNullable<CommandInput['data']>> {
-	/** Details about what kind of data this command accepts. Any object (even an empty one) permits data. The keys inside this object provide details about the data. */
-	data: {
-		/** A description of what kind of data should be provided, to be shown on help screens. */
-		description?: string;
-
-		/** Whether data must be provided to this command. */
-		required?: true;
-
-		/** What type of data should be provided. Invalid data will be rejected. */
-		type?: number extends Data ? 'integer' | 'float' : never; // TODO: this needs improving
-
-		/** A finite array of acceptable data strings. Invalid data will be rejected. */
-		accepts?: string[];
-
-		/** Whether to ignore anything that looks like flags/options once data is reached. Useful if you expect your data to contain things that would otherwise appear to be flags/options. */
-		ignoreFlagsAndOptions?: true;
-	};
-}
-
-interface BaseCommandSpec {
+/** Describes a command's specifications */
+export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitExcludeMeProperties<{
 	/** A description of this command, to be shown on help screens. */
 	description?: string;
 
@@ -91,30 +31,119 @@ interface BaseCommandSpec {
 	executeOnCascade?: true;
 
 	/** Whether this command accepts pass-through arguments (arguments that follow ` -- `). Pass-through arguments are intended to be handed off to another program being executed by this command. */
+	acceptsPassThroughArgs: undefined extends Input['acceptsPassThroughArgs'] ? ExcludeMe : true;
+
+	/** Permitted boolean arguments. */
+	flags: 'flags' extends keyof Input
+		? NonNullable<Input['flags']> extends never
+			? ExcludeMe
+			: {
+					[Flag in keyof Input['flags']]: {
+						/** A description of this flag, to be shown on help screens. */
+						description?: string;
+
+						/** Whether this flag also applies to commands farther down in the file tree. */
+						cascades?: true;
+
+						/** A single-character that could be used instead of the full flag name. */
+						shorthand?: string;
+					};
+			  }
+		: ExcludeMe;
+
+	/** Permitted key/value arguments. */
+	options: 'options' extends keyof Input
+		? NonNullable<Input['options']> extends never
+			? ExcludeMe
+			: {
+					[Option in keyof Input['options']]: OmitExcludeMeProperties<{
+						/** A description of this option, to be shown on help screens. */
+						description?: string;
+
+						/** Whether this option also applies to commands farther down in the file tree. */
+						cascades?: true;
+
+						/** A single-character that could be used instead of the full option name. */
+						shorthand?: string;
+
+						/** Whether this option must be provided with this command. */
+						required: undefined extends Input['options'][Option] ? ExcludeMe : true;
+
+						/** What type of value should be provided. Invalid values will be rejected. */
+						type: number extends Input['options'][Option]
+							? Input['options'][Option] extends number
+								? 'integer' | 'float'
+								: ExcludeMe
+							: ExcludeMe;
+
+						/** A finite array of acceptable option values. Invalid values will be rejected. */
+						accepts: NonNullable<Input['options'][Option]> extends Array<string | number>
+							? Input['options'][Option]
+							: ExcludeMe;
+					}>;
+			  }
+		: ExcludeMe;
+
+	/** Details about what kind of data this command accepts. Any object (even an empty one) permits data. */
+	data: 'data' extends keyof Input
+		? NonNullable<Input['data']> extends never
+			? ExcludeMe
+			: OmitExcludeMeProperties<{
+					/** A description of what kind of data should be provided, to be shown on help screens. */
+					description?: string;
+
+					/** Whether data must be provided to this command. */
+					required: undefined extends Input['data'] ? ExcludeMe : true;
+
+					/** What type of data should be provided. Invalid data will be rejected. */
+					type: number extends Input['data']
+						? Input['data'] extends number
+							? 'integer' | 'float'
+							: ExcludeMe
+						: ExcludeMe;
+
+					/** A finite array of acceptable data values. Invalid data will be rejected. */
+					accepts: NonNullable<Input['data']> extends Array<string | number> ? Input['data'] : ExcludeMe;
+
+					/** Whether to ignore anything that looks like flags/options once data is reached. Useful if you expect your data to contain things that would otherwise appear to be flags/options. */
+					ignoreFlagsAndOptions?: true;
+			  }>
+		: ExcludeMe;
+}>;
+
+// Describes what a command spec might look like after being imported
+export interface GenericCommandSpec {
+	description?: string;
+	executeOnCascade?: true;
 	acceptsPassThroughArgs?: true;
+	flags?: {
+		[flag: string]: {
+			description?: string;
+			cascades?: true;
+			shorthand?: string;
+		};
+	};
+	options?: {
+		[option: string]: {
+			description?: string;
+			cascades?: true;
+			shorthand?: string;
+			required?: true;
+			type?: 'integer' | 'float';
+			accepts?: string[] | number[];
+		};
+	};
+	data?: {
+		description?: string;
+		required?: true;
+		type?: 'integer' | 'float';
+		accepts?: string[] | number[];
+		ignoreFlagsAndOptions?: true;
+	};
 }
 
-export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = undefined extends Input['flags']
-	? undefined extends Input['options']
-		? undefined extends Input['data']
-			? BaseCommandSpec
-			: BaseCommandSpec & RequiredData<NonNullable<Input['data']>>
-		: undefined extends Input['data']
-		? BaseCommandSpec & RequiredOptions<NonNullable<Input['options']>>
-		: BaseCommandSpec & RequiredOptions<NonNullable<Input['options']>> & RequiredData<NonNullable<Input['data']>>
-	: undefined extends Input['options']
-	? undefined extends Input['data']
-		? BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>>
-		: BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>> & RequiredData<NonNullable<Input['data']>>
-	: undefined extends Input['data']
-	? BaseCommandSpec & RequiredFlags<NonNullable<Input['flags']>> & RequiredOptions<NonNullable<Input['options']>>
-	: BaseCommandSpec &
-			RequiredFlags<NonNullable<Input['flags']>> &
-			RequiredOptions<NonNullable<Input['options']>> &
-			RequiredData<NonNullable<Input['data']>>;
-
 /** Get the parsed command spec from a particular directory */
-export default async function getCommandSpec(directory: string): Promise<Partial<CommandSpec<AnyCommandInput>>> {
+export default async function getCommandSpec(directory: string): Promise<GenericCommandSpec> {
 	// Error if directory does not exist
 	if (!fs.existsSync(directory)) {
 		throw new Error(`Directory does not exist: ${directory}`);
@@ -146,9 +175,7 @@ export default async function getCommandSpec(directory: string): Promise<Partial
 
 	// Return
 	try {
-		const spec = (await import(specFilePath)) as
-			| { default: CommandSpec<EmptyCommandInput> }
-			| CommandSpec<EmptyCommandInput>;
+		const spec = (await import(specFilePath)) as { default: GenericCommandSpec } | GenericCommandSpec;
 		return 'default' in spec ? spec.default : spec;
 	} catch (error) {
 		throw new PrintableError(

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -6,6 +6,7 @@ import printPrettyError from './print-pretty-error.js';
 import chalk from './chalk.js';
 import path from 'path';
 import { InputObject } from './construct-input-object.js';
+import { AnyCommandInput } from './get-command-spec.js';
 
 // Define what a fully-constructed config object looks like
 export interface Config {
@@ -22,7 +23,7 @@ export interface Config {
 	usageCommand: string;
 
 	/** An optional function to call when the program is first executed. */
-	onStart?: (inputObject: InputObject) => Promise<void>;
+	onStart?: (inputObject: InputObject<AnyCommandInput>) => Promise<void>;
 
 	/** Extra whitespace automatically printed around your program’s output for aesthetics. */
 	spacing: {

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -5,8 +5,7 @@ import getContext from './get-context.js';
 import printPrettyError from './print-pretty-error.js';
 import chalk from './chalk.js';
 import path from 'path';
-import { InputObject } from './construct-input-object.js';
-import { AnyCommandInput } from './get-command-spec.js';
+import { ConstructedInputObject } from './construct-input-object.js';
 
 // Define what a fully-constructed config object looks like
 export interface Config {
@@ -23,7 +22,7 @@ export interface Config {
 	usageCommand: string;
 
 	/** An optional function to call when the program is first executed. */
-	onStart?: (inputObject: InputObject<AnyCommandInput>) => Promise<void>;
+	onStart?: (inputObject: ConstructedInputObject) => Promise<void>;
 
 	/** Extra whitespace automatically printed around your program’s output for aesthetics. */
 	spacing: {

--- a/src/utils/get-merged-spec.ts
+++ b/src/utils/get-merged-spec.ts
@@ -1,13 +1,10 @@
 // Imports
 import path from 'path';
-import getCommandSpec, { CommandSpec } from './get-command-spec.js';
+import getCommandSpec, { AnyCommandInput, CommandSpec } from './get-command-spec.js';
 import getContext from './get-context.js';
 
 // Define what a merged spec looks like
-type MergedSpec = CommandSpec & {
-	flags: NonNullable<CommandSpec['flags']>;
-	options: NonNullable<CommandSpec['options']>;
-};
+type MergedSpec = Partial<CommandSpec<AnyCommandInput>>;
 
 /** Retrieve the merged specifications for a command, taking into consideration parent specs */
 export default async function getMergedSpec(command: string): Promise<MergedSpec> {
@@ -48,6 +45,10 @@ export default async function getMergedSpec(command: string): Promise<MergedSpec
 		if (typeof spec.flags === 'object') {
 			Object.entries(spec.flags).forEach(([flag, details]) => {
 				if (index === pieces.length - 1 || details.cascades === true) {
+					if (mergedSpec.flags === undefined) {
+						throw new Error('This should not be possible');
+					}
+
 					mergedSpec.flags[flag] = details;
 				}
 			});
@@ -56,6 +57,10 @@ export default async function getMergedSpec(command: string): Promise<MergedSpec
 		if (typeof spec.options === 'object') {
 			Object.entries(spec.options).forEach(([option, details]) => {
 				if (index === pieces.length - 1 || details.cascades === true) {
+					if (mergedSpec.options === undefined) {
+						throw new Error('This should not be possible');
+					}
+
 					mergedSpec.options[option] = details;
 				}
 			});

--- a/src/utils/get-merged-spec.ts
+++ b/src/utils/get-merged-spec.ts
@@ -1,10 +1,10 @@
 // Imports
 import path from 'path';
-import getCommandSpec, { AnyCommandInput, CommandSpec } from './get-command-spec.js';
+import getCommandSpec, { GenericCommandSpec } from './get-command-spec.js';
 import getContext from './get-context.js';
 
 // Define what a merged spec looks like
-type MergedSpec = Partial<CommandSpec<AnyCommandInput>>;
+type MergedSpec = GenericCommandSpec;
 
 /** Retrieve the merged specifications for a command, taking into consideration parent specs */
 export default async function getMergedSpec(command: string): Promise<MergedSpec> {

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -41,7 +41,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 	let previousOption: string | undefined = undefined;
 	let nextIsOptionValue = false;
 	let nextValueType: string | undefined = undefined;
-	let nextValueAccepts: string[] | undefined = undefined;
+	let nextValueAccepts: string[] | number[] | undefined = undefined;
 	let reachedData = false;
 	let reachedPassThrough = false;
 
@@ -77,15 +77,6 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 			let value: string | number = argument;
 
 			// Validate value, if necessary
-			if (Array.isArray(nextValueAccepts)) {
-				const accepts: string[] = nextValueAccepts;
-				if (accepts.includes(value) === false) {
-					throw new PrintableError(
-						`Unrecognized value for ${String(previousOption)}: ${value}\nAccepts: ${accepts.join(', ')}`
-					);
-				}
-			}
-
 			if (nextValueType) {
 				if (nextValueType === 'integer') {
 					if (/^[0-9]+$/.test(value)) {
@@ -101,6 +92,17 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 					}
 				} else {
 					throw new PrintableError(`Unrecognized "type": ${nextValueType}`);
+				}
+			}
+
+			if (Array.isArray(nextValueAccepts)) {
+				const accepts = nextValueAccepts;
+
+				// @ts-expect-error: TypeScript is confused here...
+				if (accepts.includes(value) === false) {
+					throw new PrintableError(
+						`Unrecognized value for ${String(previousOption)}: ${value}\nAccepts: ${accepts.join(', ')}`
+					);
 				}
 			}
 
@@ -281,6 +283,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 
 		// Validate data, if necessary
 		if (mergedSpec.data.accepts) {
+			// @ts-expect-error: TypeScript is confused here...
 			if (!mergedSpec.data.accepts.includes(organizedArguments.data)) {
 				throw new PrintableError(
 					`Unrecognized data for "${organizedArguments.command.trim()}": ${


### PR DESCRIPTION
This PR allows the consumer of Waterfall CLI to utilize stricter types, specifically with the `CommandSpec` and `CommandFunction ` types. This is achieved by defining an `Input` type and handing it to these now-generic types.

For example, you could create an interface that looks like:

```ts
// example.spec.ts
export interface Input {
    flags: {
        quiet: true;
    };
    data: string;
}
```

Then you can hand it to both `CommandSpec<Input>` and `CommandFunction<Input>`.