### PR TITLE
Don't pass help/version flags to commands

### DIFF
--- a/src/utils/construct-input-object.test.ts
+++ b/src/utils/construct-input-object.test.ts
@@ -31,10 +31,8 @@ describe('#constructInputObject()', () => {
 				sort: 'popularity',
 			},
 			flags: {
-				help: false,
 				quiet: true,
 				vegetarian: true,
-				version: false,
 			},
 		});
 	});

--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -55,6 +55,10 @@ export default async function constructInputObject(): Promise<ConstructedInputOb
 
 	// Loop over each component and store
 	Object.entries(mergedSpec.flags ?? {}).forEach(([flag]) => {
+		if (['help', 'version'].includes(flag)) {
+			return;
+		}
+
 		const camelCaseKey = convertDashesToCamelCase(flag);
 
 		if (!inputObject.flags) {


### PR DESCRIPTION
These aren't useful because if either is passed, Spark intercepts it and displays the corresponding screen. So `help` and `version` would _always_ be `false` once it reaches the command function.