### PR TITLE
Fix structure and type for the input object

### DIFF
--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -98,7 +98,9 @@ export default async function constructInputObject(): Promise<ConstructedInputOb
 	}
 
 	// Store data
-	inputObject.data = organizedArguments.data;
+	if (typeof mergedSpec.data === 'object') {
+		inputObject.data = organizedArguments.data;
+	}
 
 	// Store command
 	inputObject.command = organizedArguments.command;

--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -48,6 +48,15 @@ export default async function constructInputObject(): Promise<ConstructedInputOb
 	// Get merged spec for this command
 	const mergedSpec = await getMergedSpec(organizedArguments.command);
 
+	// Initialize some keys, in case the objects are empty
+	if (typeof mergedSpec.flags === 'object') {
+		inputObject.flags = {};
+	}
+
+	if (typeof mergedSpec.options === 'object') {
+		inputObject.options = {};
+	}
+
 	// Convert a string from aaa-aaa-aaa to aaaAaaAaa
 	const convertDashesToCamelCase = (string: string): string => {
 		return string.replace(/-(.)/g, (g) => g[1].toUpperCase());

--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -25,7 +25,15 @@ export type InputObject<Input extends CommandInput> = OmitExcludeMeProperties<{
 		  };
 
 	/** If provided, the data given to this command. */
-	data: undefined extends Input['data'] ? ExcludeMe : string | number;
+	data: 'data' extends keyof Input
+		? NonNullable<Input['data']> extends never
+			? ExcludeMe
+			: NonNullable<Input['data']> extends Array<string | number>
+			? undefined extends Input['data']
+				? NonNullable<Input['data']>[number] | undefined
+				: NonNullable<Input['data']>[number]
+			: Input['data']
+		: ExcludeMe;
 
 	/** If provided, an array of pass-through arguments. */
 	passThroughArgs?: undefined extends Input['acceptsPassThroughArgs'] ? ExcludeMe : string[];


### PR DESCRIPTION
When constructing the input object, a few things have changed to tighten it up:

1. The `data` key will only be added if data is expected.
2. The `data` key's type has been fixed. Previously it was inaccurate in several situations.
3. The `flags` and `options` keys will be empty objects if empty objects are defined in the command spec. Previously they would have been missing altogether, since they were only being initialized to empty objects whenever the first flag/option was encountered.