### PR TITLE
Better spec error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/utils/get-command-spec.test.ts
+++ b/src/utils/get-command-spec.test.ts
@@ -19,7 +19,7 @@ describe('#getCommandSpec()', () => {
 
 	it('Complains about invalid spec JS', async () => {
 		await expect(getCommandSpec(path.join(testFileTrees, 'bad-structure', 'cli', 'invalid-spec-js'))).rejects.toThrow(
-			'This spec file contains invalid JS'
+			'Encountered this error while importing the spec file at'
 		);
 	});
 

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import chalk from './chalk.js';
 import { PrintableError } from './errors.js';
 import { ExcludeMe, OmitExcludeMeProperties } from '../types/exclude-matching-properties.js';
+import getContext from './get-context.js';
 
 // Define what command input looks like
 export interface CommandInput {
@@ -170,8 +171,12 @@ export default async function getCommandSpec(directory: string): Promise<Generic
 		);
 	}
 
-	// Get the file path
+	// Get the context
+	const context = await getContext();
+
+	// Get the file paths
 	const specFilePath = specFiles[0];
+	const truncatedPath = specFilePath.replace(`${path.dirname(context.entryFile)}/`, '');
 
 	// Return
 	try {
@@ -179,7 +184,7 @@ export default async function getCommandSpec(directory: string): Promise<Generic
 		return 'default' in spec ? spec.default : spec;
 	} catch (error) {
 		throw new PrintableError(
-			`This spec file contains invalid JS: ${specFilePath}\n${chalk.bold('JS Error: ')}${String(error)}`
+			`${String(error)}\n\nEncountered this error while importing the spec file at: ${chalk.bold(truncatedPath)}`
 		);
 	}
 }


### PR DESCRIPTION
This improves the error message that's printed whenever invalid JS is encountered in a spec file; it matches the format of the improved error message for invalid JS in commands.