### PR TITLE
Introduce an expose a `HandledError`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.2",
+	"version": "1.0.0-alpha.3",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,18 @@
 // Export directly
 export { default as init } from './actions/init.js';
 export { default as printError } from './utils/print-pretty-error.js';
-export { PrintableError } from './utils/errors.js';
+export { PrintableError, HandledError } from './utils/errors.js';
 
 // Export as default
 import init from './actions/init.js';
 import printError from './utils/print-pretty-error.js';
-import { PrintableError } from './utils/errors.js';
+import { PrintableError, HandledError } from './utils/errors.js';
 
 export default {
 	init,
 	printError,
 	PrintableError,
+	HandledError,
 };
 
 // Expose some types to consumers

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,11 @@
+/** This error indicates it was expected and already handled */
+export class HandledError extends Error {
+	constructor(message?: string) {
+		super(message);
+		this.name = 'HandledError';
+	}
+}
+
 /** This error indicates it was expected, and a pretty error message should be printed */
 export class PrintableError extends Error {
 	constructor(message: string) {


### PR DESCRIPTION
This error can be thrown by clients, indicating that the program should exit with an error code, but no error message should be printed. This is useful for situations where the program already has a mechanism for showing an error to the user, so they don't want duplicate information to appear.