### PR TITLE
Support multiple data items

### DIFF
--- a/src/utils/get-organized-arguments.test.ts
+++ b/src/utils/get-organized-arguments.test.ts
@@ -64,6 +64,25 @@ describe('#getOrganizedArguments()', () => {
 		});
 	});
 
+	it('Handles multiple data', async () => {
+		process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'list',
+			'two',
+			'words',
+			'crusts',
+		];
+
+		expect(await getOrganizedArguments()).toStrictEqual({
+			flags: [],
+			options: [],
+			values: [],
+			data: 'two words crusts',
+			command: 'list',
+		});
+	});
+
 	it('Handles simple command with flag after data', async () => {
 		(process.argv = [
 			'/path/to/node',

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -291,12 +291,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 			let remnants = ` ${organizedArguments.data} `;
 
 			for (const current of mergedSpec.data.accepts) {
-				const find = ` ${current} `;
-				const foundAt = remnants.indexOf(find);
-
-				if (foundAt >= 0) {
-					remnants = remnants.substr(0, foundAt) + remnants.substr(foundAt + find.length - 1);
-				}
+				remnants = remnants.replace(` ${current} `, ' ');
 			}
 
 			remnants = remnants.trim();

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -291,7 +291,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 			let remnants = ` ${organizedArguments.data} `;
 
 			for (const current of mergedSpec.data.accepts) {
-				remnants = remnants.replace(` ${current} `, ' ');
+				remnants = remnants.replace(` ${current} `, ' '); // Space-padding to guard against partial matches
 			}
 
 			remnants = remnants.trim();

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -287,12 +287,26 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 
 		// Validate data, if necessary
 		if (mergedSpec.data.accepts && mergedSpec.data.accepts instanceof Array) {
-			// @ts-expect-error: TypeScript is confused here...
-			if (!mergedSpec.data.accepts.includes(organizedArguments.data)) {
+			// Find unrecognized data by removing acceptable values
+			let remnants = ` ${organizedArguments.data} `;
+
+			for (const current of mergedSpec.data.accepts) {
+				const find = ` ${current} `;
+				const foundAt = remnants.indexOf(find);
+
+				if (foundAt >= 0) {
+					remnants = remnants.substr(0, foundAt) + remnants.substr(foundAt + find.length - 1);
+				}
+			}
+
+			remnants = remnants.trim();
+
+			// Error if unknown remnants remain
+			if (remnants.length > 0) {
 				throw new PrintableError(
-					`Unrecognized data for "${organizedArguments.command.trim()}": ${
-						organizedArguments.data
-					}\nAccepts: ${mergedSpec.data.accepts.join(', ')}`
+					`Unrecognized data for "${organizedArguments.command.trim()}": ${remnants}\nAccepts: ${mergedSpec.data.accepts.join(
+						', '
+					)}`
 				);
 			}
 		}


### PR DESCRIPTION
Closes #370 

This change allows multiple `data.accepts` items to be accepted (even if multi-word).

Previously, only a *single* `data.accepts` item was allowed.

A test for this situation has also been provided.

