### PR TITLE
Improve `accepts` definition

### DIFF
--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -28,11 +28,7 @@ export type InputObject<Input extends CommandInput> = OmitExcludeMeProperties<{
 	data: 'data' extends keyof Input
 		? NonNullable<Input['data']> extends never
 			? ExcludeMe
-			: NonNullable<Input['data']> extends Array<string | number>
-			? undefined extends Input['data']
-				? NonNullable<Input['data']>[number] | undefined
-				: NonNullable<Input['data']>[number]
-			: Input['data']
+			: Input['data'] | (undefined extends Input['data'] ? undefined : never)
 		: ExcludeMe;
 
 	/** If provided, an array of pass-through arguments. */

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -69,10 +69,9 @@ type ArrayItemType<T> = T extends Array<infer Item> ? Item : T;
 // Guard against multiple types being combined. Decide whether multiple responses are accepted. Decide whether accepts is optional or not, and determine type for accepts
 type SingleAcceptTypeOrNever<T, U> = DetectMultipleTypes<T> extends true
 	? never
-	: {
-			acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe;
-			accepts: AcceptTypes<ArrayItemType<T>> | (undefined extends U ? undefined : never);
-	  };
+	: { acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe } & (undefined extends U
+			? { accepts?: AcceptTypes<ArrayItemType<T>> }
+			: { accepts: AcceptTypes<ArrayItemType<T>> });
 
 // Prevent unacceptable types, or provide type definitions
 type Acceptables<T> = NonNullable<T> extends string | number | string[] | number[]

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -81,7 +81,10 @@ export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitEx
 
 						/** A finite array of acceptable option values or callback providing same. Invalid values will be rejected. */
 						accepts: NonNullable<Input['options'][Option]> extends string | number | string[] | number[]
-							? AlwaysArray<Input['options'][Option]> | (() => (AlwaysArray<Input['options'][Option]>)) | (() => Promise<(AlwaysArray<Input['options'][Option]>)>)
+							?
+									| AlwaysArray<Input['options'][Option]>
+									| (() => AlwaysArray<Input['options'][Option]>)
+									| (() => Promise<AlwaysArray<Input['options'][Option]>>)
 							: ExcludeMe;
 					}>;
 			  }
@@ -107,7 +110,10 @@ export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitEx
 
 					/** A finite array of acceptable data values or callback providing same. Invalid data will be rejected. */
 					accepts: NonNullable<Input['data']> extends string | number | string[] | number[]
-						? AlwaysArray<Input['data']> | (() => AlwaysArray<Input['data']>) | (() => Promise<AlwaysArray<Input['data']>>)
+						?
+								| AlwaysArray<Input['data']>
+								| (() => AlwaysArray<Input['data']>)
+								| (() => Promise<AlwaysArray<Input['data']>>)
 						: ExcludeMe;
 
 					/** Whether to ignore anything that looks like flags/options once data is reached. Useful if you expect your data to contain things that would otherwise appear to be flags/options. */

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -66,7 +66,7 @@ type AcceptTypes<T> = IsLiteral<T> extends true
 // Get type of array elements
 type ArrayItemType<T> = T extends Array<infer Item> ? Item : T;
 
-// Guard against multiple types being combined. Decide whether multiple responses are accepted. Decide whether accepts is optional or not, and determine type for accepts
+// Guard against multiple types being combined; decide whether multiple responses are accepted; decide whether accepts is optional or not, and determine type for accepts
 type SingleAcceptTypeOrNever<T, U> = DetectMultipleTypes<T> extends true
 	? never
 	: { acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe } & (undefined extends U

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -71,7 +71,7 @@ type IsAcceptsOptional<T> = IsLiteral<T> extends true ? false : true;
 
 // Decide whether numeric type identifier is needed; decide whether to flag as required; decide whether multiple responses are accepted; decide whether accepts is optional or not, and determine type for accepts
 type DataTypeAddons<T, U> = {
-	/** What type of data should be provided. Invalid data will be rejected. */
+	/** What type of numeric data should be provided. Invalid data will be rejected. */
 	type: number extends U ? (U extends number ? 'integer' | 'float' : ExcludeMe) : ExcludeMe;
 
 	/** Must be defined as true when data must be provided to this command, otherwise must be omitted. */

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -74,7 +74,7 @@ type DataTypeAddons<T, U> = {
 	/** What type of numeric data should be provided. Invalid data will be rejected. */
 	type: number extends U ? (U extends number ? 'integer' | 'float' : ExcludeMe) : ExcludeMe;
 
-	/** Must be defined as true when data must be provided to this command, otherwise must be omitted. */
+	/** Must be defined as `true` when data must be provided to this command, otherwise must be omitted. */
 	required: undefined extends U ? ExcludeMe : true;
 
 	/** Must be defined as true when multiple elements are accepted, otherwise must be omitted. */

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -77,7 +77,7 @@ type DataTypeAddons<T, U> = {
 	/** Must be defined as true when data must be provided to this command, otherwise must be omitted. */
 	required: undefined extends U ? ExcludeMe : true;
 
-	/** Required when multiple values are accepted. */
+	/** Must be defined as true when multiple elements are accepted, otherwise must be omitted. */
 	acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe;
 } & (IsAcceptsOptional<U> extends true
 	? {

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -70,7 +70,7 @@ type ArrayItemType<T> = T extends Array<infer Item> ? Item : T;
 type SingleAcceptTypeOrNever<T, U> = DetectMultipleTypes<T> extends true
 	? never
 	: {
-			acceptsMultiple: T extends Array<unknown> ? true : never;
+			acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe;
 			accepts: AcceptTypes<ArrayItemType<T>> | (undefined extends U ? undefined : never);
 	  };
 

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -61,7 +61,7 @@ type DetectMultipleTypes<T> = IsUnion<UnionTypes<T>>;
 // Decide what the accepts type will expand to
 type AcceptTypes<T> = IsLiteral<T> extends true
 	? AlwaysArray<T>
-	: (() => AlwaysArray<T>) | (() => Promise<AlwaysArray<T>>);
+	: AlwaysArray<T> | (() => AlwaysArray<T>) | (() => Promise<AlwaysArray<T>>);
 
 // Get type of array elements
 type ArrayItemType<T> = T extends Array<infer Item> ? Item : T;

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -77,7 +77,7 @@ type DataTypeAddons<T, U> = {
 	/** Must be defined as `true` when data must be provided to this command, otherwise must be omitted. */
 	required: undefined extends U ? ExcludeMe : true;
 
-	/** Must be defined as true when multiple elements are accepted, otherwise must be omitted. */
+	/** Must be defined as `true` when multiple elements are accepted, otherwise must be omitted. */
 	acceptsMultiple: T extends Array<unknown> ? true : ExcludeMe;
 } & (IsAcceptsOptional<U> extends true
 	? {

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -23,6 +23,8 @@ export type EmptyCommandInput = {
 	[Key in keyof Required<CommandInput>]: undefined;
 };
 
+type AlwaysArray<T> = T extends Array<infer Item> ? Item[] : undefined extends T ? NonNullable<T> | undefined : T[];
+
 /** Describes a command's specifications */
 export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitExcludeMeProperties<{
 	/** A description of this command, to be shown on help screens. */
@@ -78,12 +80,8 @@ export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitEx
 							: ExcludeMe;
 
 						/** A finite array of acceptable option values or callback providing same. Invalid values will be rejected. */
-						accepts: NonNullable<Input['options'][Option]> extends
-							| string[]
-							| number[]
-							| (() => string[] | number[])
-							| (() => Promise<string[] | number[]>)
-							? Input['options'][Option] | (() => Promise<Input['options'][Option]>)
+						accepts: NonNullable<Input['options'][Option]> extends string | number | string[] | number[]
+							? AlwaysArray<Input['options'][Option]> | (() => (AlwaysArray<Input['options'][Option]>)) | (() => Promise<(AlwaysArray<Input['options'][Option]>)>)
 							: ExcludeMe;
 					}>;
 			  }
@@ -108,12 +106,8 @@ export type CommandSpec<Input extends CommandInput = EmptyCommandInput> = OmitEx
 						: ExcludeMe;
 
 					/** A finite array of acceptable data values or callback providing same. Invalid data will be rejected. */
-					accepts: NonNullable<Input['data']> extends
-						| string[]
-						| number[]
-						| (() => string[] | number[])
-						| (() => Promise<string[] | number[]>)
-						? Input['data'] | (() => Promise<Input['data']>)
+					accepts: NonNullable<Input['data']> extends string | number | string[] | number[]
+						? AlwaysArray<Input['data']> | (() => AlwaysArray<Input['data']>) | (() => Promise<AlwaysArray<Input['data']>>)
 						: ExcludeMe;
 
 					/** Whether to ignore anything that looks like flags/options once data is reached. Useful if you expect your data to contain things that would otherwise appear to be flags/options. */


### PR DESCRIPTION
Closes #374 

Flexible enough to allow the following:

Input interface `.data`| spec object type | command handler `.data`
----- | ---- | -----
| (`data` is omitted) | data element must be omitted | '.data' not defined on the input object
| data?: string | data: { accepts?: string[] \| (() => (string[] \| Promise<string[]>))} | string \| undefined
| data: string | data: { required: true; accepts?: string[] \| (() => (string[] \| Promise<string[]>))} | string
| data?: string[] | data: { acceptsMultiple: true; accepts?: string[] \| (() => (string[] \| Promise<string[]>))} | string[] \| undefined
| data: string[] | data: { required: true; acceptsMultiple: true; accepts?: string[] \| (() => (string[] \| Promise<string[]>))} | string[]
| data?: 'v1' \| 'v2' | data: { accepts?: 'v1' \| 'v2' } | 'v1'\|'v2'
| data: 'v1' \| 'v2' | data: { required: true, accepts: 'v1' \| 'v2' } | 'v1'\|'v2'
| data:? ('v1' \| 'v2')[] | data: { acceptsMultiple: true; accepts?: ('v1' \| 'v2')[] } | ('v1'\|'v2')[]
| data: ('v1' \| 'v2')[] | data: { required: true, acceptsMultiple: true; accepts: ('v1' \| 'v2')[] } | ('v1'\|'v2')[]
Note: `number` may be substituted for `string` in all cases too.

