### PR TITLE
Allow `accepts` callback to respond with `undefined`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.7",
+	"version": "1.0.0-alpha.8",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/screens/help.test.ts
+++ b/src/screens/help.test.ts
@@ -198,6 +198,7 @@ describe('#helpScreen()', () => {
 
 		expect(result).toContain('What type of pizza to order');
 		expect(result).toContain('Just used for testing');
+		expect(result).not.toContain('accepts:');
 	});
 
 	it('Emits help with dynamic sync accepts properties', async () => {

--- a/src/screens/help.test.ts
+++ b/src/screens/help.test.ts
@@ -185,6 +185,21 @@ describe('#helpScreen()', () => {
 		expect(result).toContain('Just used for testing (accepts: a2, b2, c2, d2)');
 	});
 
+	it('Emits help with dynamic async accepts undefined properties', async () => {
+		process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'order',
+			'dynamic-async-accepts-undefined',
+			'--help',
+		];
+
+		const result = removeFormatting(await helpScreen());
+
+		expect(result).toContain('What type of pizza to order');
+		expect(result).toContain('Just used for testing');
+	});
+
 	it('Emits help with dynamic sync accepts properties', async () => {
 		process.argv = [
 			'/path/to/node',

--- a/src/screens/help.ts
+++ b/src/screens/help.ts
@@ -135,11 +135,13 @@ export default async function helpScreen(): Promise<string> {
 				const arrayOrPromise = typeof details.accepts === 'function' ? details.accepts() : details.accepts;
 				const accepts = arrayOrPromise instanceof Promise ? await arrayOrPromise : arrayOrPromise;
 
-				if (!(accepts instanceof Array)) {
-					throw new Error(`Error: option['${option}'].accepts must resolve to an array`);
-				}
+				if (accepts) {
+					if (!(accepts instanceof Array)) {
+						throw new Error(`Error: option['${option}'].accepts must resolve to an array`);
+					}
 
-				fullDescription += chalk.gray.italic(` (accepts: ${accepts.join(', ')})`);
+					fullDescription += chalk.gray.italic(` (accepts: ${accepts.join(', ')})`);
+				}
 			}
 
 			// Add to table

--- a/src/utils/get-all-program-commands.test.ts
+++ b/src/utils/get-all-program-commands.test.ts
@@ -16,6 +16,7 @@ describe('#getAllProgramCommands()', () => {
 			'order descriptionless-data',
 			'order dine-in',
 			'order dynamic-async-accepts',
+			'order dynamic-async-accepts-undefined',
 			'order dynamic-sync-accepts',
 			'order float-data',
 			'order integer-data',

--- a/src/utils/get-command-spec.ts
+++ b/src/utils/get-command-spec.ts
@@ -61,7 +61,7 @@ type DetectMultipleTypes<T> = IsUnion<UnionTypes<T>>;
 // Decide what the accepts type will expand to
 type AcceptTypes<T> = IsLiteral<T> extends true
 	? AlwaysArray<T>
-	: AlwaysArray<T> | (() => AlwaysArray<T> | Promise<AlwaysArray<T>>);
+	: AlwaysArray<T> | (() => AlwaysArray<T> | Promise<AlwaysArray<T> | undefined>);
 
 // Get type of array elements
 type ArrayItemType<T> = T extends Array<infer Item> ? Item : T;
@@ -180,7 +180,7 @@ export interface GenericCommandSpec {
 			shorthand?: string;
 			required?: true;
 			type?: 'integer' | 'float';
-			accepts?: string[] | number[] | (() => string[] | number[]) | (() => Promise<string[] | number[]>);
+			accepts?: string[] | number[] | (() => string[] | number[]) | (() => Promise<string[] | number[] | undefined>);
 			acceptsMultiple?: true;
 		};
 	};
@@ -188,7 +188,7 @@ export interface GenericCommandSpec {
 		description?: string;
 		required?: true;
 		type?: 'integer' | 'float';
-		accepts?: string[] | number[] | (() => string[] | number[]) | (() => Promise<string[] | number[]>);
+		accepts?: string[] | number[] | (() => string[] | number[]) | (() => Promise<string[] | number[] | undefined>);
 		ignoreFlagsAndOptions?: true;
 		acceptsMultiple?: true;
 	};
@@ -240,7 +240,7 @@ export default async function getCommandSpec(directory: string): Promise<Generic
 			spec.data.accepts = arrayOrPromise instanceof Promise ? await arrayOrPromise : arrayOrPromise;
 		}
 
-		if ((spec.data?.acceptsMultiple || spec.data?.accepts) && !(spec.data?.accepts instanceof Array)) {
+		if (spec.data?.accepts && !(spec.data?.accepts instanceof Array)) {
 			throw new Error('data.accepts must resolve to an array');
 		}
 

--- a/src/utils/get-organized-arguments.test.ts
+++ b/src/utils/get-organized-arguments.test.ts
@@ -707,6 +707,23 @@ describe('#getOrganizedArguments()', () => {
 			});
 	});
 
+	it('Handles having dynamic async option accept being undefined', async () => {
+		(process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'order',
+			'dynamic-async-accepts-undefined',
+			'--test',
+			'a2',
+		]),
+			expect(await getOrganizedArguments()).toStrictEqual({
+				command: 'order dynamic-async-accepts-undefined',
+				flags: [],
+				options: ['test'],
+				values: ['a2'],
+			});
+	});
+
 	it('Handles having dynamic sync option accept values', async () => {
 		(process.argv = [
 			'/path/to/node',
@@ -734,6 +751,23 @@ describe('#getOrganizedArguments()', () => {
 		]),
 			expect(await getOrganizedArguments()).toStrictEqual({
 				command: 'order dynamic-async-accepts',
+				flags: [],
+				options: [],
+				values: [],
+				data: 'b1',
+			});
+	});
+
+	it('Handles having dynamic async data accept being undefined', async () => {
+		(process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'order',
+			'dynamic-async-accepts-undefined',
+			'b1',
+		]),
+			expect(await getOrganizedArguments()).toStrictEqual({
+				command: 'order dynamic-async-accepts-undefined',
 				flags: [],
 				options: [],
 				values: [],

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -167,8 +167,8 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 							typeof details.accepts === 'function' ? details.accepts() : details.accepts || undefined;
 						nextValueAccepts = arrayOrPromise instanceof Promise ? await arrayOrPromise : arrayOrPromise;
 
-						// Error if accepts is not an array or absent and required
-						if ((details?.acceptsMultiple || nextValueAccepts) && !(nextValueAccepts instanceof Array)) {
+						// Error if accepts is not an array and required
+						if (nextValueAccepts && !(nextValueAccepts instanceof Array)) {
 							throw new PrintableError(`option['${option}'].accepts must resolve to an array`);
 						}
 					}

--- a/test-projects/pizza-ordering/cli/order/dynamic-async-accepts-undefined/dynamic-async-accepts-undefined.js
+++ b/test-projects/pizza-ordering/cli/order/dynamic-async-accepts-undefined/dynamic-async-accepts-undefined.js
@@ -1,0 +1,1 @@
+module.exports = async function () { };

--- a/test-projects/pizza-ordering/cli/order/dynamic-async-accepts-undefined/dynamic-async-accepts-undefined.spec.js
+++ b/test-projects/pizza-ordering/cli/order/dynamic-async-accepts-undefined/dynamic-async-accepts-undefined.spec.js
@@ -1,0 +1,24 @@
+async function dataAllows() {
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	return undefined;
+}
+
+async function testAllows() {
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	return undefined;
+}
+
+module.exports = {
+	description: 'Just used for testing',
+	data: {
+		description: 'What type of pizza to order',
+		accepts: dataAllows,
+	},
+	options: {
+		test: {
+			description: 'Just used for testing',
+			accepts: testAllows,
+		},
+	},
+	acceptsPassThroughArgs: false,
+};


### PR DESCRIPTION
Closes #384 

This change allows the `accepts`-providing async callback function to also provide `undefined`, which in turn means: any value is 'ok' during use, and, for `help` output, means there is no hint provided as to what values are acceptable.

The callback responding with `undefined` is not cause to terminate the CLI usage.

This has been done to allow the flexibility to use async functionality and put it on the same footing as would be the case with the non-async behavior.

This change also requires us to relax the previous requirement that required acceptable values to be in hand if multiple acceptable values were able to be specified.  This is because now, with `undefined` being a possibility, we are unable to require the list of acceptable values are defined in all cases.
