### PR TITLE
Fix generic option types

### DIFF
--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -21,7 +21,9 @@ export type InputObject<Input extends CommandInput> = OmitExcludeMeProperties<{
 	options: undefined extends Input['options']
 		? ExcludeMe
 		: {
-				[Option in keyof Input['options']]: string | number;
+				[Option in keyof Input['options']]:
+					| Input['options'][Option]
+					| (undefined extends Input['options'][Option] ? undefined : never);
 		  };
 
 	/** If provided, the data given to this command. */


### PR DESCRIPTION
This fixes the issue where `input.options.example` would be given the type `string | number` even when we knew the more specific type given the `Input` interface defined in the spec file.