### PR TITLE
Add VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
This adds a `.vscode/settings.json` file that specifies that VS Code should use the project's TypeScript version, not the one built into VS Code.