### PR TITLE
Fix truncated output by setting exit code instead of exiting immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.8",
+	"version": "1.0.0-alpha.9",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -167,8 +167,11 @@ export default async function init<Input extends CommandInput = EmptyCommandInpu
 				console.log();
 			}
 
-			// Exit with error code
-			process.exit(1);
+			// Set exit code to indicate error
+			process.exitCode = 1;
+
+			// Go no further
+			return;
 		}
 
 		throw error;


### PR DESCRIPTION
Fixes #522
