### PR TITLE
Revert changes to `onStart`'s `inputObject` type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waterfall-cli",
-	"version": "1.0.0-alpha.9",
+	"version": "1.0.0-alpha.10",
 	"description": "Effortlessly create CLIs powered by Node.js",
 	"types": "dist/cjs/index.d.ts",
 	"files": [

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -8,15 +8,13 @@ import getOrganizedArguments from '../utils/get-organized-arguments.js';
 import printPrettyError from '../utils/print-pretty-error.js';
 import verboseLog from '../utils/verbose-log.js';
 import path from 'path';
-import getCommandSpec, { CommandInput, EmptyCommandInput } from '../utils/get-command-spec.js';
+import getCommandSpec, { EmptyCommandInput } from '../utils/get-command-spec.js';
 import constructInputObject from '../utils/construct-input-object.js';
 import chalk from '../utils/chalk.js';
 import CommandFunction from '../types/command-function.js';
 
 /** The initialization point, which should be called at the root of your CLI app */
-export default async function init<Input extends CommandInput = EmptyCommandInput>(
-	customConfig: Partial<Config<Input>>
-): Promise<void> {
+export default async function init(customConfig: Partial<Config>): Promise<void> {
 	// Wrap in a try/catch
 	try {
 		// Get the context/config

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -5,11 +5,10 @@ import getContext from './get-context.js';
 import printPrettyError from './print-pretty-error.js';
 import chalk from './chalk.js';
 import path from 'path';
-import { InputObject } from './construct-input-object.js';
-import { CommandInput, EmptyCommandInput } from '../utils/get-command-spec.js';
+import { ConstructedInputObject } from './construct-input-object.js';
 
 // Define what a fully-constructed config object looks like
-export interface Config<Input extends CommandInput = EmptyCommandInput> {
+export interface Config {
 	/** Your program’s display name. Defaults to the `name` in its `package.json` file, if available. */
 	displayName?: string;
 
@@ -23,7 +22,7 @@ export interface Config<Input extends CommandInput = EmptyCommandInput> {
 	usageCommand: string;
 
 	/** An optional function to call when the program is first executed. */
-	onStart?: (inputObject: InputObject<Input>) => Promise<void>;
+	onStart?: (inputObject: ConstructedInputObject) => Promise<void>;
 
 	/** Extra whitespace automatically printed around your program’s output for aesthetics. */
 	spacing: {

--- a/test-projects/typescript-esm/src/entry.spec.ts
+++ b/test-projects/typescript-esm/src/entry.spec.ts
@@ -1,21 +1,6 @@
 // Import type
 import { CommandSpec } from 'waterfall-cli';
 
-// Define and export shape of input
-export interface Input {
-	flags: {
-		['verbose']: boolean;
-	};
-}
-
 // Define and export spec
-const spec: CommandSpec<Input> = {
-	flags: {
-		verbose: {
-			cascades: true,
-			description: 'Output additional details if enabled',
-			shorthand: 'v',
-		},
-	},
-};
+const spec: CommandSpec = {};
 export default spec;

--- a/test-projects/typescript-esm/src/entry.ts
+++ b/test-projects/typescript-esm/src/entry.ts
@@ -1,14 +1,6 @@
 // Import and initialize Waterfall CLI
 import waterfall from 'waterfall-cli';
-import { Input } from './entry.spec';
 
-await waterfall.init<Input>({
+await waterfall.init({
 	verbose: true,
-	onStart: async (input) => {
-		console.log(`Input object: ${JSON.stringify(input)}`);
-
-		if (input.flags.verbose) {
-			console.log('verbose is enabled!');
-		}
-	},
 });


### PR DESCRIPTION
This effectively reverts #397, which addressed #391. The reason we shouldn't be using just the entry file's `Input` interface is because the `onStart` function is actually given the fully-constructed input object, which includes all the flags, options, and data passed into the full command (which probably includes more than just what the entry file is expecting).