### PR TITLE
Allow option to have multiple comma separated values

### DIFF
--- a/src/screens/help.ts
+++ b/src/screens/help.ts
@@ -140,7 +140,7 @@ export default async function helpScreen(): Promise<string> {
 						throw new Error(`Error: option['${option}'].accepts must resolve to an array`);
 					}
 
-					fullDescription += chalk.gray.italic(` (accepts: ${accepts.join(', ')})`);
+					fullDescription += chalk.gray.italic(` (accepts${details.acceptsMultiple ? ' comma separated' : ''}: ${accepts.join(', ')})`);
 				}
 			}
 

--- a/src/screens/help.ts
+++ b/src/screens/help.ts
@@ -140,7 +140,9 @@ export default async function helpScreen(): Promise<string> {
 						throw new Error(`Error: option['${option}'].accepts must resolve to an array`);
 					}
 
-					fullDescription += chalk.gray.italic(` (accepts${details.acceptsMultiple ? ' comma separated' : ''}: ${accepts.join(', ')})`);
+					fullDescription += chalk.gray.italic(
+						` (accepts${details.acceptsMultiple ? ' comma separated' : ''}: ${accepts.join(', ')})`
+					);
 				}
 			}
 

--- a/src/utils/construct-input-object.test.ts
+++ b/src/utils/construct-input-object.test.ts
@@ -36,8 +36,8 @@ describe('#constructInputObject()', () => {
 			},
 		});
 	});
-	
-	it('Handles combination of input', async () => {
+
+	it('Handles multiple option strings', async () => {
 		process.argv = [
 			'/path/to/node',
 			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
@@ -55,7 +55,33 @@ describe('#constructInputObject()', () => {
 			},
 			options: {
 				'delivery-zip-code': undefined,
-				'hold': ['onions', 'peppers'],
+				hold: ['onions', 'peppers'],
+				size: undefined,
+				test: undefined,
+			},
+		});
+	});
+
+	it('Handles multiple option integers', async () => {
+		process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'order',
+			'to-go-without',
+			'--size',
+			'6,10,12',
+		];
+
+		expect(await constructInputObject()).toStrictEqual({
+			command: 'order to-go-without',
+			data: undefined,
+			flags: {
+				quiet: false,
+			},
+			options: {
+				'delivery-zip-code': undefined,
+				hold: undefined,
+				size: [6, 10, 12],
 				test: undefined,
 			},
 		});

--- a/src/utils/construct-input-object.test.ts
+++ b/src/utils/construct-input-object.test.ts
@@ -36,6 +36,30 @@ describe('#constructInputObject()', () => {
 			},
 		});
 	});
+	
+	it('Handles combination of input', async () => {
+		process.argv = [
+			'/path/to/node',
+			path.join(testProjectsPath, 'pizza-ordering', 'cli', 'entry.js'),
+			'order',
+			'to-go-without',
+			'--hold',
+			'onions,peppers',
+		];
+
+		expect(await constructInputObject()).toStrictEqual({
+			command: 'order to-go-without',
+			data: undefined,
+			flags: {
+				quiet: false,
+			},
+			options: {
+				'delivery-zip-code': undefined,
+				'hold': ['onions', 'peppers'],
+				test: undefined,
+			},
+		});
+	});
 
 	it('Handles passthrough inputs too', async () => {
 		process.argv = [

--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -83,7 +83,10 @@ export default async function constructInputObject(): Promise<ConstructedInputOb
 			inputObject.options = {};
 		}
 
-		inputObject.options[option] = organizedArguments.values[optionIndex];
+		const optionValue = organizedArguments.values[optionIndex];
+
+		inputObject.options[option] =
+			details.acceptsMultiple && typeof optionValue === 'string' ? optionValue.split(',') : optionValue;
 
 		if (details.required && !organizedArguments.options.includes(option)) {
 			throw new PrintableError(`The --${option} option is required`);

--- a/src/utils/construct-input-object.ts
+++ b/src/utils/construct-input-object.ts
@@ -83,10 +83,7 @@ export default async function constructInputObject(): Promise<ConstructedInputOb
 			inputObject.options = {};
 		}
 
-		const optionValue = organizedArguments.values[optionIndex];
-
-		inputObject.options[option] =
-			details.acceptsMultiple && typeof optionValue === 'string' ? optionValue.split(',') : optionValue;
+		inputObject.options[option] = organizedArguments.values[optionIndex];
 
 		if (details.required && !organizedArguments.options.includes(option)) {
 			throw new PrintableError(`The --${option} option is required`);

--- a/src/utils/get-all-program-commands.test.ts
+++ b/src/utils/get-all-program-commands.test.ts
@@ -22,6 +22,7 @@ describe('#getAllProgramCommands()', () => {
 			'order integer-data',
 			'order single-topping',
 			'order to-go',
+			'order to-go-without',
 		]);
 	});
 });

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -16,7 +16,7 @@ interface OrganizedArguments {
 	data?: string | number | string[] | number[];
 	flags: string[];
 	options: string[];
-	values: (string | number)[];
+	values: (string | number | string[] | number[])[];
 	passThrough?: string[];
 }
 
@@ -40,9 +40,9 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 
 	let previousOption: string | undefined = undefined;
 	let nextIsOptionValue = false;
+	let nextOptionAcceptsMultiple = false;
 	let nextValueType: string | undefined = undefined;
 	let nextValueAccepts: string[] | number[] | undefined = undefined;
-	let nextValueAcceptsMultiple: boolean | undefined = undefined;
 	let reachedData = false;
 	let reachedPassThrough = false;
 
@@ -74,57 +74,68 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 			// Verbose output
 			await verboseLog(`...Is value for previous option (${String(previousOption)})`);
 
-			// Initialize
-			let value: string | number = argument;
-
-			// Validate value, if necessary
-			if (nextValueType) {
-				if (nextValueType === 'integer') {
-					if (/^[0-9]+$/.test(value)) {
-						value = parseInt(value, 10);
-					} else {
-						throw new PrintableError(`The option ${String(previousOption)} expects an integer\nProvided: ${value}`);
-					}
-				} else if (nextValueType === 'float') {
-					if (/^[0-9]*[.]*[0-9]*$/.test(value) && value !== '.' && value !== '') {
-						value = parseFloat(value);
-					} else {
-						throw new PrintableError(`The option ${String(previousOption)} expects a float\nProvided: ${value}`);
-					}
-				} else {
-					throw new PrintableError(`Unrecognized "type": ${nextValueType}`);
-				}
-			}
-
-			if (Array.isArray(nextValueAccepts)) {
-				const accepts = nextValueAccepts;
-
-				// @ts-expect-error: TypeScript is confused here...
-				if (!nextValueAcceptsMultiple && accepts.includes(value) === false) {
-					throw new PrintableError(
-						`Unrecognized value for ${String(previousOption)}: ${value}\nAccepts: ${accepts.join(', ')}`
-					);
-				}
-
-				if (nextValueAcceptsMultiple && typeof value === 'string') {
-					// Split value into individual elements
-					const valueItems = value.split(',').map((item) => item.trim());
-
-					// Check that each element is acceptable
-					for (const valueItem of valueItems) {
-						// @ts-expect-error: TypeScript is confused here...
-						if (!accepts.includes(valueItem)) {
-							throw new PrintableError(
-								`Unrecognized value for ${String(previousOption)}: ${valueItem}\nAccepts: ${accepts.join(', ')}`
-							);
+			// Helper that returns a valid value or throws
+			const validValue = (value: string): string | number => {
+				if (nextValueType) {
+					if (nextValueType === 'integer') {
+						if (/^[0-9]+$/.test(value)) {
+							return parseInt(value, 10);
+						} else {
+							throw new PrintableError(`The option ${String(previousOption)} expects an integer\nProvided: ${value}`);
 						}
+					} else if (nextValueType === 'float') {
+						if (/^[0-9]*[.]*[0-9]*$/.test(value) && value !== '.' && value !== '') {
+							return parseFloat(value);
+						} else {
+							throw new PrintableError(`The option ${String(previousOption)} expects a float\nProvided: ${value}`);
+						}
+					} else {
+						throw new PrintableError(`Unrecognized "type": ${nextValueType}`);
 					}
 				}
+
+				if (Array.isArray(nextValueAccepts)) {
+					const accepts = nextValueAccepts;
+
+					// @ts-expect-error: TypeScript is confused here...
+					if (accepts.includes(value) === false) {
+						throw new PrintableError(
+							`Unrecognized value for ${String(previousOption)}: ${value}\nAccepts: ${accepts.join(', ')}`
+						);
+					}
+				}
+
+				return value;
+			};
+
+			// Handle comma-separated values for acceptsMultiple options
+			if (nextOptionAcceptsMultiple) {
+				const parts = argument.split(',');
+				const processed = {
+					strings: [] as string[],
+					numbers: [] as number[],
+				};
+
+				for (const part of parts) {
+					const valid = validValue(part);
+
+					if (typeof valid === 'string') {
+						processed.strings.push(valid);
+					} else if (typeof valid === 'number') {
+						processed.numbers.push(valid);
+					}
+				}
+
+				// Store and continue
+				nextIsOptionValue = false;
+				nextOptionAcceptsMultiple = false;
+				organizedArguments.values.push(processed.strings.length > 0 ? processed.strings : processed.numbers);
+				continue;
 			}
 
 			// Store and continue
 			nextIsOptionValue = false;
-			organizedArguments.values.push(value);
+			organizedArguments.values.push(validValue(argument));
 			continue;
 		}
 
@@ -176,9 +187,9 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 						// Store details
 						previousOption = argument;
 						nextIsOptionValue = true;
+						nextOptionAcceptsMultiple = details.acceptsMultiple === true;
 						nextValueType = details.type || undefined;
 						organizedArguments.options.push(option);
-						nextValueAcceptsMultiple = details.acceptsMultiple;
 
 						const arrayOrPromise =
 							typeof details.accepts === 'function' ? details.accepts() : details.accepts || undefined;

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -108,7 +108,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 
 				if (nextValueAcceptsMultiple && typeof value === 'string') {
 					// Split value into individual elements
-					const valueItems = value.split(',').map((v) => v.trim());
+					const valueItems = value.split(',').map((item) => item.trim());
 
 					// Check that each element is acceptable
 					for (const valueItem of valueItems) {

--- a/src/utils/get-organized-arguments.ts
+++ b/src/utils/get-organized-arguments.ts
@@ -42,6 +42,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 	let nextIsOptionValue = false;
 	let nextValueType: string | undefined = undefined;
 	let nextValueAccepts: string[] | number[] | undefined = undefined;
+	let nextValueAcceptsMultiple: boolean | undefined = undefined;
 	let reachedData = false;
 	let reachedPassThrough = false;
 
@@ -99,10 +100,25 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 				const accepts = nextValueAccepts;
 
 				// @ts-expect-error: TypeScript is confused here...
-				if (accepts.includes(value) === false) {
+				if (!nextValueAcceptsMultiple && accepts.includes(value) === false) {
 					throw new PrintableError(
 						`Unrecognized value for ${String(previousOption)}: ${value}\nAccepts: ${accepts.join(', ')}`
 					);
+				}
+
+				if (nextValueAcceptsMultiple && typeof value === 'string') {
+					// Split value into individual elements
+					const valueItems = value.split(',').map((v) => v.trim());
+
+					// Check that each element is acceptable
+					for (const valueItem of valueItems) {
+						// @ts-expect-error: TypeScript is confused here...
+						if (!accepts.includes(valueItem)) {
+							throw new PrintableError(
+								`Unrecognized value for ${String(previousOption)}: ${valueItem}\nAccepts: ${accepts.join(', ')}`
+							);
+						}
+					}
 				}
 			}
 
@@ -162,6 +178,7 @@ export default async function getOrganizedArguments(): Promise<OrganizedArgument
 						nextIsOptionValue = true;
 						nextValueType = details.type || undefined;
 						organizedArguments.options.push(option);
+						nextValueAcceptsMultiple = details.acceptsMultiple;
 
 						const arrayOrPromise =
 							typeof details.accepts === 'function' ? details.accepts() : details.accepts || undefined;

--- a/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.js
+++ b/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.js
@@ -1,0 +1,1 @@
+module.exports = async function() {};

--- a/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.spec.js
+++ b/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.spec.js
@@ -14,6 +14,12 @@ module.exports = {
 			acceptsMultiple: true,
 			accepts: ['olives', 'onions', 'peppers', 'sauce'],
 		},
+		size: {
+			description: 'What size pizza to order',
+			acceptsMultiple: true,
+			type: 'integer',
+			accepts: [6, 10, 12],
+		}
 	},
 	acceptsPassThroughArgs: true,
 };

--- a/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.spec.js
+++ b/test-projects/pizza-ordering/cli/order/to-go-without/to-go-without.spec.js
@@ -1,0 +1,19 @@
+module.exports = {
+	description: 'Order a pizza, to-go',
+	data: {
+		description: 'What type of pizza to order',
+		type: 'fake',
+	},
+	options: {
+		test: {
+			description: 'Just used for testing',
+			type: 'fake',
+		},
+		hold: {
+			description: 'What ingredients to hold',
+			acceptsMultiple: true,
+			accepts: ['olives', 'onions', 'peppers', 'sauce'],
+		},
+	},
+	acceptsPassThroughArgs: true,
+};


### PR DESCRIPTION
Closes #623 

Currently, when multiple valid options are provided as separate pairs of option + value, only the first option value is presented to the application.

eg: 

> --optionName value1 --optionName value2

only `value1` will be present within `input.options.optionName` string array.

This change allows the following:

> --optionName value1,value2

and for the application to see both values within `input.options.optionName` (which is a string array)

If one of the values are not valid, it will be called out as such.

I've also included a test variant that specifically validates that the multi-value behavior is functioning as expected.